### PR TITLE
issue #27, being unable to tip some accounts is prevented

### DIFF
--- a/public/templates/post.html
+++ b/public/templates/post.html
@@ -61,7 +61,7 @@
           </ul>
     </div>
 
-		<div class="row" ng-show="simpleWallet">
+		<div ng-if="post.user.addressBCH" class="row" ng-show="simpleWallet">
 			<ul class="list-unstyled list-inline list">
 				<li>
 					<button ng-disabled="upvotingPostId === post.id || post.userId === profile.id" ng-click="addressClicked(post)" class="btn btn-default">
@@ -84,17 +84,21 @@
 			<div class="block-center">
 				<div class="panel">
 					<div class="panel-body">
-						<h2>This author does not accept tips.</h2>
+						<b ng-if="post.userId !== profile.id">This author does not accept tips.</b>
 
-						<p>
+						<!--
+								there is no need for this because since when the author logs in they will have a wallet.
+								when they are not logged in this will not be visible to anyone anyways.
+								
+							 <p ng-if="post.userId === profile.id">
 							<strong>Important:</strong> You can specify the address for receiving tips in your profile.
-						</p>
+						</p> -->
 					</div>
 				</div>
 			</div>
 		</div>
 
-		<div class="row" ng-show="post.user.addressBCH">
+		<div class="row" ng-if="post.user.addressBCH">
 			<div class="block-center">
 				<div class="panel" ng-show="!user" >
 					<div class="panel-body">
@@ -123,7 +127,7 @@
 			{{post.userPostRefs[0].extId}}
 		</div>
 
-		<div class="row" ng-show="post.userPostUpvotes">
+		<div class="row" ng-if="post.userPostUpvotes && post.user.addressBCH">
 			<h4><i class="fa fa-btc"></i> <strong>Upvotes ({{post.userPostUpvotes.length}})</strong></h4>
 
 			<p ng-if="!post.userPostUpvotes.length"><small>No upvotes.</small></p>

--- a/public/templates/post.html
+++ b/public/templates/post.html
@@ -80,19 +80,11 @@
 
 		<hr />
 
-		<div class="row" ng-show="!post.user.addressBCH">
+		<div class="row" ng-if="!post.user.addressBCH">
 			<div class="block-center">
 				<div class="panel">
 					<div class="panel-body">
-						<b ng-if="post.userId !== profile.id">This author does not accept tips.</b>
-
-						<!--
-								there is no need for this because since when the author logs in they will have a wallet.
-								when they are not logged in this will not be visible to anyone anyways.
-								
-							 <p ng-if="post.userId === profile.id">
-							<strong>Important:</strong> You can specify the address for receiving tips in your profile.
-						</p> -->
+						<b>This author does not accept tips.</b>
 					</div>
 				</div>
 			</div>
@@ -122,7 +114,7 @@
 			</div>
 		</div>
 
-		<div class="post-uncensorable row" ng-if="post.userPostRefs.length" style="margin-bottom: 20px;">
+		<div class="post-uncensorable row" ng-if="post.userPostRefs.length && post.user.addressBCH"" style="margin-bottom: 20px;">
 			<h4><i class="fa fa-shield"></i>  <strong>Uncensorable</strong></h4>
 			{{post.userPostRefs[0].extId}}
 		</div>


### PR DESCRIPTION
addresses the issue #27 with the following changes to prevent readers from tipping when the author does not have a BTC address to send reader's tip.:

- the following will be hidden: upvote button, upvotes section, uncensorable section
- the following will be visible only to readers: A notification that says "This author does not accept tips."