### PR TITLE
horizontal scroll bug still persisting

### DIFF
--- a/public/templates/layout.html
+++ b/public/templates/layout.html
@@ -115,7 +115,7 @@
 
 	<div style="min-height:440px;">
 		<div style="height:25px;"></div>
-		<div ui-view autoscroll="true"></div>
+		<div ui-view class="container" autoscroll="true"></div>
 	</div>
 
 	<script type="text/ng-template" id="searchResults.html">

--- a/src/app/components/feed/template.html
+++ b/src/app/components/feed/template.html
@@ -65,12 +65,12 @@
 			<div class="row feed-actions" style="padding-top: 10px; padding-bottom: 10px;">
 				<div class="col-xs-12">
 					<ul class="list-unstyled list-inline list">
-						<li ng-if="feed.user.addressBCH" style="width:50px;">
+						<li style="width:50px;">
 							<button ng-click="addressClicked(feed)" class="btn btn-default" ng-disabled="upvotingPostId === feed.id">
 								<i class="fa fa-btc"></i> 0.002</a>
 							</button>
 						</li>
-						<li ng-if="feed.user.addressBCH" style="width:50px;">
+						<li style="width:50px;">
 							<small>{{feed.upvoteCount}} <i class="fa fa-bitcoin"></i></small>
             </li>
             <li style="width:50px;">

--- a/src/app/components/feed/template.html
+++ b/src/app/components/feed/template.html
@@ -65,12 +65,12 @@
 			<div class="row feed-actions" style="padding-top: 10px; padding-bottom: 10px;">
 				<div class="col-xs-12">
 					<ul class="list-unstyled list-inline list">
-						<li style="width:50px;">
+						<li ng-if="feed.user.addressBCH" style="width:50px;">
 							<button ng-click="addressClicked(feed)" class="btn btn-default" ng-disabled="upvotingPostId === feed.id">
 								<i class="fa fa-btc"></i> 0.002</a>
 							</button>
 						</li>
-						<li style="width:50px;">
+						<li ng-if="feed.user.addressBCH" style="width:50px;">
 							<small>{{feed.upvoteCount}} <i class="fa fa-bitcoin"></i></small>
             </li>
             <li style="width:50px;">


### PR DESCRIPTION
bootstrap requires container class to have correctly reset the positive and negative margins/paddings that it applies to rows and columns. Adding the container class to the parent fixed the horizontal scrolling issue.

Also fixed the left margins/paddings on the whole website aswell:
Normally you would have 15px gutters on both sides on x-axis with bootstrap. these were not regarded before which made the posts on the profile page get listed with left side with margin 0 and right side with some margins whilst they should be equal.