### PR TITLE
Prevented PostService from upvoting when author has no tipping address

### DIFF
--- a/src/app/components/feed/template.html
+++ b/src/app/components/feed/template.html
@@ -65,12 +65,12 @@
 			<div class="row feed-actions" style="padding-top: 10px; padding-bottom: 10px;">
 				<div class="col-xs-12">
 					<ul class="list-unstyled list-inline list">
-						<li style="width:50px;">
+						<li ng-if="post.user.addressBCH" style="width:50px;">
 							<button ng-click="addressClicked(feed)" class="btn btn-default" ng-disabled="upvotingPostId === feed.id">
 								<i class="fa fa-btc"></i> 0.002</a>
 							</button>
 						</li>
-						<li style="width:50px;">
+						<li ng-if="post.user.addressBCH" style="width:50px;">
 							<small>{{feed.upvoteCount}} <i class="fa fa-bitcoin"></i></small>
             </li>
             <li style="width:50px;">

--- a/src/app/controllers/MainCtrl.ts
+++ b/src/app/controllers/MainCtrl.ts
@@ -96,6 +96,12 @@ export default class MainCtrl {
 
         const addressClicked = async (post) => {
             const postId = post.id;
+
+            if (!post.user.addressBCH) {
+                toastr.error("Upvoting is not possible because the author does not have a Bitcoin address to receive");
+                return;
+            }
+
             const address = post.user.addressBCH;
             const simpleWallet = simpleWalletProvider.get();
 


### PR DESCRIPTION
- added a frontend check to prevent PostService from upvoting if the author does not have a tipping address
- also removed the upvote button and the upvote count (or received bitcoin amount) from the posts that are listed on the profile page