### PR TITLE
horizontal scroll in mobile when viewing feed

### DIFF
--- a/src/app/components/feed/feed.css
+++ b/src/app/components/feed/feed.css
@@ -94,6 +94,7 @@
 .feed-body {
 	cursor: pointer;
 	width:100% !important;
+	word-wrap: break-word;
 }
 
 .feed-body lazy-img {


### PR DESCRIPTION
long text in the feed sometimes cause horizontal scroll. the word now breaks into new line thus no overflow will happen