### PR TITLE
image sizing problem in the feed

### DIFF
--- a/src/app/components/feed/feed.css
+++ b/src/app/components/feed/feed.css
@@ -33,7 +33,15 @@
 
 .feed-image {
   display: block;
-  height: 200px;
+	/* 
+		the image in the feed will:
+			1) if taller than the container, the height will be limited to 200px
+			and the rest of the image will be overflown and hidden
+			2) if shorten than the container, the container will shrink
+			to the size of the image 
+			max-height: 200px;
+	*/
+	max-height: 200px; 
   line-height: 200px;
   margin-left: auto;
   margin-right: auto;

--- a/src/core/style.css
+++ b/src/core/style.css
@@ -99,7 +99,7 @@ h4 {
 img.lazy {
   width: 100%;
   /*max-height: 400px;*/
-  min-height: 180px;
+  /* min-height: 180px; */ /* this causes scaling problems */
   display: block;
   /* optional way, set loading as background */
   background-image: url('/img/loader-pacman.gif');


### PR DESCRIPTION
the image in the feed will:
- if taller than the container, the height will be limited to 200px and the rest of the image will be overflown - if shorten than the container, the container will shrink to the size of the image