### PR TITLE
Added post title cutoff over 75 characters

### DIFF
--- a/src/app/components/uncensorable-button/uncensorable-button.component.ts
+++ b/src/app/components/uncensorable-button/uncensorable-button.component.ts
@@ -112,9 +112,10 @@ class UncensorableButtonController {
         let res;
 
         try {
+          const postTitle = post.title.length > 75 ? post.title.slice(0, 75) + "..." : post.title;
           res = await simpleWallet.upload(compressedJson, {
             ext: "json.lzutf8",
-            title: `${post.title} by ${post.user.username} | Honest Cash`,
+            title: `${postTitle} by ${post.user.username} | Honest Cash`,
             extUri: `https://honest.cash/post/${post.id}`
           });
         } catch (err) {


### PR DESCRIPTION
* If the title of a post is longer than 75 characters it is cut off.
* This is a bit on the conservative side, since the actual number for most regular usernames is around 90, but this way we allow longer usernames without any additional logic.