### PR TITLE
HC-166 / Signin appearing before editor momentarily

### DIFF
--- a/honestcash-v2/package.json
+++ b/honestcash-v2/package.json
@@ -13,8 +13,10 @@
     "serve:ssr": "node dist/server",
     "build:ssr:prod": "npm run build:client-and-server-bundles:prod && npm run compile:server",
     "build:ssr:dev": "npm run build:client-and-server-bundles:dev && npm run compile:server",
+    "build:ssr:local": "npm run build:client-and-server-bundles:local && npm run compile:server",
     "build:client-and-server-bundles:prod": "ng build --prod --base-href /v2/ --deploy-url /v2/ && ng run honestcash-v2:server:production",
-    "build:client-and-server-bundles:dev": "ng build --configuration development --base-href /v2/ --deploy-url /v2/ && ng run honestcash-v2:server:development"
+    "build:client-and-server-bundles:dev": "ng build --configuration development --base-href /v2/ --deploy-url /v2/ && ng run honestcash-v2:server:development",
+    "build:client-and-server-bundles:local": "ng build --configuration development && ng run honestcash-v2:server:development"
   },
   "private": true,
   "dependencies": {

--- a/honestcash-v2/src/app/app-routing.module.ts
+++ b/honestcash-v2/src/app/app-routing.module.ts
@@ -1,6 +1,5 @@
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
-import {environment} from '../environments/environment';
 
 /**
  * - More specific routes should come first
@@ -18,7 +17,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, {enableTracing: !environment.production})],
+  imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
 export class AppRoutingModule {

--- a/honestcash-v2/src/app/app-routing.module.ts
+++ b/honestcash-v2/src/app/app-routing.module.ts
@@ -1,5 +1,6 @@
-import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import {NgModule} from '@angular/core';
+import {RouterModule, Routes} from '@angular/router';
+import {environment} from '../environments/environment';
 
 /**
  * - More specific routes should come first
@@ -17,7 +18,8 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, {enableTracing: !environment.production})],
   exports: [RouterModule]
 })
-export class AppRoutingModule {}
+export class AppRoutingModule {
+}

--- a/honestcash-v2/src/app/modules/editor/editor.module.ts
+++ b/honestcash-v2/src/app/modules/editor/editor.module.ts
@@ -26,11 +26,10 @@ const routes: Routes = [
     path: '',
     component: EditorContainerComponent,
     children: [
-      {path: 'write', pathMatch: 'full', component: EditorWriteComponent, canActivate: [AuthorizedGuard]},
-      {path: 'edit/:storyId', pathMatch: 'full', component: EditorEditComponent, canActivate: [AuthorizedGuard]},
+      {path: 'write', component: EditorWriteComponent, canActivate: [AuthorizedGuard]},
+      {path: 'edit/:storyId', component: EditorEditComponent, canActivate: [AuthorizedGuard]},
       {
         path: 'story-preview',
-        pathMatch: 'full',
         component: EditorStoryPreviewComponent,
         canActivate: [AuthorizedGuard, LocallySavedStoryGuard]
       },

--- a/honestcash-v2/src/app/modules/welcome/welcome.module.ts
+++ b/honestcash-v2/src/app/modules/welcome/welcome.module.ts
@@ -28,31 +28,32 @@ const routes: Routes = [
     children: [
       {
         path: '',
-        pathMatch: 'full',
+        redirectTo: '/welcome',
+        pathMatch: 'full'
+      },
+      {
+        path: 'welcome',
         component: WelcomeComponent,
         canActivate: [UnauthorizedGuard]
       },
       {path: 'about', component: AboutComponent},
       {
         path: 'login',
-        pathMatch: 'full',
         component: LoginComponent,
         canActivate: [UnauthorizedGuard],
       },
-      {path: 'logout', pathMatch: 'full', component: LogoutComponent, canActivate: [AuthorizedGuard]},
+      {path: 'logout', component: LogoutComponent, canActivate: [AuthorizedGuard]},
       {
         path: 'signup',
-        pathMatch: 'full',
         component: SignupComponent,
         canActivate: [UnauthorizedGuard],
       },
       {
         path: 'reset-password-request/:resetCode',
-        pathMatch: 'full',
         component: ResetPasswordVerifyComponent,
         canActivate: [UnauthorizedGuard]
       },
-      {path: 'reset-password-request', pathMatch: 'full', component: ResetPasswordRequestComponent, canActivate: [UnauthorizedGuard]},
+      {path: 'reset-password-request', component: ResetPasswordRequestComponent, canActivate: [UnauthorizedGuard]},
       {path: 'thank-you', component: ThankYouComponent, canActivate: [AuthorizedGuard]},
     ]
   }

--- a/honestcash-v2/src/app/shared/guards/authorized.guard.ts
+++ b/honestcash-v2/src/app/shared/guards/authorized.guard.ts
@@ -1,23 +1,38 @@
-import {Injectable} from '@angular/core';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '@angular/router';
 
 import {Logger} from '../services/logger.service';
 import {AuthService} from '../services/auth.service';
+import {isPlatformBrowser} from '@angular/common';
 
 const log = new Logger('AuthorizedGuard');
 
 @Injectable({providedIn: 'root'})
 export class AuthorizedGuard implements CanActivate {
-  constructor(private router: Router, private authenticationService: AuthService) {
+  private isPlatformBrowser: boolean;
+
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: any,
+    private router: Router,
+    private authenticationService: AuthService
+  ) {
+    this.isPlatformBrowser = isPlatformBrowser(this.platformId);
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    if (this.authenticationService.hasAuthorization()) {
-      return true;
-    }
+    if (this.isPlatformBrowser) {
+      if (this.authenticationService.hasAuthorization()) {
+        return true;
+      }
 
-    log.debug('Unauthorized, redirecting to login page...');
-    this.router.navigate(['/login'], {queryParams: {redirect: state.url}, replaceUrl: true});
-    return false;
+      log.debug('Unauthorized, redirecting to login page...');
+      this.router.navigate(['/login'], {queryParams: {redirect: state.url}, replaceUrl: true});
+      return false;
+    }
+    // during SSR, as localStorage is undefined and thus the user is not authenticated, it will always redirect user to login
+    // which will cause login page to appear until client rendering takes over
+    // by then localStorage is defined and if the user exists, user will see the correct route
+    return true;
+
   }
 }

--- a/honestcash-v2/src/app/shared/guards/locally-stored-story.guard.ts
+++ b/honestcash-v2/src/app/shared/guards/locally-stored-story.guard.ts
@@ -6,13 +6,14 @@ import {WindowToken} from '../../core/helpers/window';
 import {EnvironmentToken} from '../../core/helpers/environment';
 import {Environment} from '../../../environments/environment';
 import {EditorService} from '../../modules/editor/services/editor.service';
-import {isPlatformBrowser} from '@angular/common';
+import {isPlatformBrowser, isPlatformServer} from '@angular/common';
 
 const log = new Logger('LocallySavedStoryGuard');
 
 @Injectable({providedIn: 'root'})
 export class LocallySavedStoryGuard implements CanActivate {
-  private isPlatformBrowser: boolean;
+  readonly isPlatformBrowser: boolean;
+  readonly isPlatformServer: boolean;
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: any,
@@ -22,6 +23,7 @@ export class LocallySavedStoryGuard implements CanActivate {
     private editorService: EditorService,
   ) {
     this.isPlatformBrowser = isPlatformBrowser(this.platformId);
+    this.isPlatformServer = isPlatformServer(this.platformId);
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
@@ -32,8 +34,10 @@ export class LocallySavedStoryGuard implements CanActivate {
       this.router.navigate(['/editor/write']);
       return false;
     }
-    // to cheat SSR until client takes over
-    return true;
+    if (this.isPlatformServer) {
+      // to cheat SSR until client takes over
+      return true;
+    }
   }
 
 }

--- a/honestcash-v2/src/app/shared/guards/locally-stored-story.guard.ts
+++ b/honestcash-v2/src/app/shared/guards/locally-stored-story.guard.ts
@@ -1,4 +1,4 @@
-import {Inject, Injectable} from '@angular/core';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '@angular/router';
 
 import {Logger} from '../services/logger.service';
@@ -6,25 +6,34 @@ import {WindowToken} from '../../core/helpers/window';
 import {EnvironmentToken} from '../../core/helpers/environment';
 import {Environment} from '../../../environments/environment';
 import {EditorService} from '../../modules/editor/services/editor.service';
+import {isPlatformBrowser} from '@angular/common';
 
 const log = new Logger('LocallySavedStoryGuard');
 
 @Injectable({providedIn: 'root'})
 export class LocallySavedStoryGuard implements CanActivate {
+  private isPlatformBrowser: boolean;
+
   constructor(
+    @Inject(PLATFORM_ID) private platformId: any,
     @Inject(WindowToken) private window: Window,
     @Inject(EnvironmentToken) private environment: Environment,
     private router: Router,
     private editorService: EditorService,
   ) {
+    this.isPlatformBrowser = isPlatformBrowser(this.platformId);
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    if (this.editorService.getLocallySavedPost()) {
-      return true;
+    if (this.isPlatformBrowser) {
+      if (this.editorService.getLocallySavedPost()) {
+        return true;
+      }
+      this.router.navigate(['/editor/write']);
+      return false;
     }
-    this.router.navigate(['/editor/write']);
-    return false;
+    // to cheat SSR until client takes over
+    return true;
   }
 
 }

--- a/honestcash-v2/src/app/shared/guards/unauthorized.guard.ts
+++ b/honestcash-v2/src/app/shared/guards/unauthorized.guard.ts
@@ -1,4 +1,4 @@
-import {Inject, Injectable} from '@angular/core';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {CanActivate, Router} from '@angular/router';
 
 import {Logger} from '../services/logger.service';
@@ -6,35 +6,44 @@ import {AuthService} from '../services/auth.service';
 import {WindowToken} from '../../core/helpers/window';
 import {EnvironmentToken} from '../../core/helpers/environment';
 import {Environment} from '../../../environments/environment';
+import {isPlatformBrowser} from '@angular/common';
 
 const log = new Logger('UnauthorizedGuard');
 
 @Injectable({providedIn: 'root'})
 export class UnauthorizedGuard implements CanActivate {
+  private isPlatformBrowser: boolean;
+
   constructor(
+    @Inject(PLATFORM_ID) private platformId: any,
     @Inject(WindowToken) private window: Window,
     @Inject(EnvironmentToken) private environment: Environment,
     private router: Router,
     private authenticationService: AuthService
   ) {
+    this.isPlatformBrowser = isPlatformBrowser(this.platformId);
   }
 
   canActivate(): boolean {
-    if (!this.authenticationService.hasAuthorization()) {
-      return true;
-    }
+    if (this.isPlatformBrowser) {
+      if (!this.authenticationService.hasAuthorization()) {
+        return true;
+      }
 
-    // @ todo change when feed is introduced
-    log.debug('Already logged in, redirecting to v1');
-    if (this.environment.production) {
-      this.window.location.href = '/';
-    } else {
-      // or route to v1 port in localhost
-      // so that it does not go into endless loop
-      // in v2 / all over
-      this.window.location.href = 'http://localhost:3010/';
-    }
+      // @ todo change when feed is introduced
+      log.debug('Already logged in, redirecting to v1');
+      if (this.environment.production) {
+        this.window.location.href = '/';
+      } else {
+        // or route to v1 port in localhost
+        // so that it does not go into endless loop
+        // in v2 / all over
+        this.window.location.href = 'http://localhost:3010/';
+      }
 
-    return false;
+      return false;
+    }
+    // to cheat SSR until client takes over
+    return true;
   }
 }

--- a/honestcash-v2/src/app/shared/guards/unauthorized.guard.ts
+++ b/honestcash-v2/src/app/shared/guards/unauthorized.guard.ts
@@ -6,13 +6,14 @@ import {AuthService} from '../services/auth.service';
 import {WindowToken} from '../../core/helpers/window';
 import {EnvironmentToken} from '../../core/helpers/environment';
 import {Environment} from '../../../environments/environment';
-import {isPlatformBrowser} from '@angular/common';
+import {isPlatformBrowser, isPlatformServer} from '@angular/common';
 
 const log = new Logger('UnauthorizedGuard');
 
 @Injectable({providedIn: 'root'})
 export class UnauthorizedGuard implements CanActivate {
-  private isPlatformBrowser: boolean;
+  readonly isPlatformBrowser: boolean;
+  readonly isPlatformServer: boolean;
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: any,
@@ -22,6 +23,7 @@ export class UnauthorizedGuard implements CanActivate {
     private authenticationService: AuthService
   ) {
     this.isPlatformBrowser = isPlatformBrowser(this.platformId);
+    this.isPlatformServer = isPlatformServer(this.platformId);
   }
 
   canActivate(): boolean {
@@ -43,7 +45,9 @@ export class UnauthorizedGuard implements CanActivate {
 
       return false;
     }
-    // to cheat SSR until client takes over
-    return true;
+    if (this.isPlatformServer) {
+      // to cheat SSR until client takes over
+      return true;
+    }
   }
 }

--- a/honestcash-v2/src/app/shared/guards/version-one.guard.ts
+++ b/honestcash-v2/src/app/shared/guards/version-one.guard.ts
@@ -1,4 +1,4 @@
-import {Inject, Injectable} from '@angular/core';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '@angular/router';
 
 import {Logger} from '../services/logger.service';
@@ -7,48 +7,63 @@ import {WALLET_SETUP_STATUS, WalletService} from '../services/wallet.service';
 import {WindowToken} from '../../core/helpers/window';
 import {EnvironmentToken} from '../../core/helpers/environment';
 import {Environment} from '../../../environments/environment';
-import {Observable} from 'rxjs';
+import {Observable, of} from 'rxjs';
 import {map} from 'rxjs/operators';
+import {isPlatformBrowser} from '@angular/common';
 
 const log = new Logger('VersionOneGuard');
 
 @Injectable({providedIn: 'root'})
 export class VersionOneGuard implements CanActivate {
+  private isPlatformBrowser: boolean;
+
   constructor(
+    @Inject(PLATFORM_ID) private platformId: any,
     @Inject(WindowToken) private window: Window,
     @Inject(EnvironmentToken) private environment: Environment,
     private router: Router,
     private authenticationService: AuthService,
     private walletService: WalletService,
   ) {
+    this.isPlatformBrowser = isPlatformBrowser(this.platformId);
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    if (this.authenticationService.hasAuthorization() && this.walletService.getWalletMnemonic()) {
-      log.debug('Already logged in, redirecting to v1');
-      if (this.environment.env === 'prod' || this.environment.env === 'dev') {
-        this.window.location.href = '/';
-      } else {
-        // or route to v1 port in localhost
-        // so that it does not go into endless loop
-        // in v2 / all over
-        this.window.location.href = 'http://localhost:3010/';
+    if (this.isPlatformBrowser) {
+      if (this.authenticationService.hasAuthorization() && this.walletService.getWalletMnemonic()) {
+        log.debug('Already logged in, redirecting to v1');
+        if (this.environment.env === 'prod' || this.environment.env === 'dev') {
+          this.window.location.href = '/';
+        } else {
+          // or route to v1 port in localhost
+          // so that it does not go into endless loop
+          // in v2 / all over
+          this.window.location.href = 'http://localhost:3010/';
+        }
+        return false;
       }
-      return false;
+      return true;
     }
+    // during SSR, as localStorage is undefined and thus the user is not authenticated, it will always redirect user to login
+    // which will cause login page to appear until client rendering takes over
+    // by then localStorage is defined and if the user exists, user will see the correct route
     return true;
   }
 
   canDeactivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-    return this.walletService.getWalletSetupStatus()
-    .pipe(
-      map((status: WALLET_SETUP_STATUS) => {
-        if (status === WALLET_SETUP_STATUS.Initialized) {
-          return true;
-        }
-        return false;
-      }),
-    );
+    if (this.isPlatformBrowser) {
+      return this.walletService.getWalletSetupStatus()
+      .pipe(
+        map((status: WALLET_SETUP_STATUS) => {
+          if (status === WALLET_SETUP_STATUS.Initialized) {
+            return true;
+          }
+          return false;
+        }),
+      );
+    }
+    // to cheat SSR until client takes over
+    return of(true);
   }
 
 }


### PR DESCRIPTION
- removed pathMatches (unneccessary) from route,
- the server was rendering guards which have no localStorage (via authService) during execution which results in user being unauthenticated then being redirected to login page. this is undesired thus a isPlatformBrowser check was implemented in guards.

the checks of isPlatformBrowser could have been added to authService `hasAuthorization` but then it would falsly show user as authenticated just to bypass guards rendered by SSR thus that method is not used