### PR TITLE
HC-192 / editor plus toolbar weird look

### DIFF
--- a/honestcash-v2/src/app/modules/editor/components/editor/editor.component.scss
+++ b/honestcash-v2/src/app/modules/editor/components/editor/editor.component.scss
@@ -78,6 +78,10 @@
       font-weight: normal;
     }
 
+    .ce-toolbar__plus {
+      left: -34px !important;
+    }
+
     h1.ce-header {
       font-size: 2.5rem;
     }


### PR DESCRIPTION
- moved plus icon to the left by -34px instead of +5px