### PR TITLE
HC-242 / v1 redirects to certain honest_cash articles

### DIFF
--- a/app.js
+++ b/app.js
@@ -245,16 +245,28 @@ for (let editorPath of [ "/markdown/write", "/markdown/edit/:postId", "/markdown
 */
 
 // PATHS MIGRATED TO V2
+
+// Story
 app.get("/:username/:postId", (req, res) => res.redirect(`/v2/${req.params.username}/${req.params.postId}`));
 app.get("/post/:username/:postId", (req, res) => res.redirect(`/v2/post/${req.params.username}/${req.params.postId}`));
 app.get("/post/:postId", (req, res) => res.redirect(`/v2/post/${req.params.postId}`));
 app.get("/story/:username/:postId", (req, res) => res.redirect(`/v2/story/${req.params.username}/${req.params.postId}`));
 app.get("/story/:postId", (req, res) => res.redirect(`/v2/story/${req.params.postId}`));
+
+// Editor
 app.get("/write", (_, res) => res.redirect(`/v2/editor/write`));
 app.get("/edit/:postId", (req, res) => res.redirect(`/v2/editor/edit/${req.params.postId}`));
 app.get("/write/response/:parentPostId", (req, res) => res.redirect(`/v2/editor/comment/${req.params.parentPostId}`));
 
-for (let v2Path of [ "/login", "/signup", "/thank-you", "/about" ]) {
+// Main
+for (let v2Path of [ "/terms-of-service", "/about-honest-cash", "/privacy-policy", "transparency" ]) {
+	app.get(v2Path, (_, res) =>
+		res.redirect(`/v2${v2Path}`)
+	);
+}
+
+// Auth
+for (let v2Path of [ "/login", "/signup", "/thank-you" ]) {
   app.get(v2Path, (_, res) =>
     res.redirect(`/v2${v2Path}`)
   );

--- a/honestcash-v2/src/app/auth/components/footer/footer.component.html
+++ b/honestcash-v2/src/app/auth/components/footer/footer.component.html
@@ -4,7 +4,7 @@
   <ul class="list-inline mb-0">
     <li class="list-inline-item">
     <a
-      [routerLink]="['/about']"
+      [routerLink]="['/about-honest-cash']"
       class="nav-link text-white"
       >About</a
     >
@@ -12,27 +12,27 @@
     <li class="list-inline-item">
     <a
     class="nav-link text-white"
-      href="https://honest.cash/honest_cash/frequently-asked-questions"
+      [routerLink]="['/frequently-asked-questions']"
       >FAQ</a
     >
     </li>
     <li class="list-inline-item">
     <a
       class="nav-link text-white"
-      href="https://honest.cash/honest_cash/honest-cash-transparency-report-and-warrant-canary-129"
+      [routerLink]="['/transparency']"
       >Transparency</a
     >
     </li>
     <li class="list-inline-item">
     <a
-      href="https://honest.cash/honest_cash/honest-cash-terms-of-service-124"
+      [routerLink]="['/terms-of-service']"
       class="nav-link text-white"
       >Terms</a
     >
     </li>
     <li class="list-inline-item">
     <a
-      href="https://honest.cash/honest_cash/honestcash-privacy-policy"
+      [routerLink]="['/privacy-policy']"
       class="nav-link text-white"
       >Privacy</a
     >

--- a/honestcash-v2/src/app/auth/pages/welcome/welcome.component.html
+++ b/honestcash-v2/src/app/auth/pages/welcome/welcome.component.html
@@ -5,6 +5,9 @@
 >
 </auth-heading>
 <div class="card-body">
+  <a class="btn btn-dark btn-block font-weight-bold text-uppercase" [routerLink]="['/about']">
+    Learn About Honest Cash
+  </a>
   <a class="btn btn-dark btn-block font-weight-bold text-uppercase" [routerLink]="['/signup']">
     Get Started
   </a>

--- a/honestcash-v2/src/app/main/main-routing.module.ts
+++ b/honestcash-v2/src/app/main/main-routing.module.ts
@@ -5,6 +5,7 @@ import {MainAboutComponent} from './pages/about/about.component';
 import {MainTermsOfServiceComponent} from './pages/terms-of-service/terms-of-service.component';
 import {MainPrivacyPolicyComponent} from './pages/privacy-policy/privacy-policy.component';
 import {MainFaqComponent} from './pages/faq/faq.component';
+import {MainTransparencyComponent} from './pages/transparency/transparency.component';
 
 /**
  * - More specific routes should come first
@@ -15,8 +16,10 @@ const routes: Routes = [
     component: MainContainerComponent,
     children: [
       {path: 'about', component: MainAboutComponent},
+      {path: 'about-honest-cash', component: MainAboutComponent},
       {path: 'terms-of-service', component: MainTermsOfServiceComponent},
       {path: 'privacy-policy', component: MainPrivacyPolicyComponent},
+      {path: 'transparency', component: MainTransparencyComponent},
       {path: 'help', component: MainFaqComponent},
       {path: 'faq', component: MainFaqComponent},
       {path: 'frequently-asked-questions', component: MainFaqComponent},

--- a/honestcash-v2/src/app/main/main-routing.module.ts
+++ b/honestcash-v2/src/app/main/main-routing.module.ts
@@ -6,6 +6,7 @@ import {MainTermsOfServiceComponent} from './pages/terms-of-service/terms-of-ser
 import {MainPrivacyPolicyComponent} from './pages/privacy-policy/privacy-policy.component';
 import {MainFaqComponent} from './pages/faq/faq.component';
 import {MainTransparencyComponent} from './pages/transparency/transparency.component';
+import {MainAboutHonestCashComponent} from './pages/about-honest-cash/about-honest-cash.component';
 
 /**
  * - More specific routes should come first
@@ -16,7 +17,7 @@ const routes: Routes = [
     component: MainContainerComponent,
     children: [
       {path: 'about', component: MainAboutComponent},
-      {path: 'about-honest-cash', component: MainAboutComponent},
+      {path: 'about-honest-cash', component: MainAboutHonestCashComponent},
       {path: 'terms-of-service', component: MainTermsOfServiceComponent},
       {path: 'privacy-policy', component: MainPrivacyPolicyComponent},
       {path: 'transparency', component: MainTransparencyComponent},

--- a/honestcash-v2/src/app/main/main.module.ts
+++ b/honestcash-v2/src/app/main/main.module.ts
@@ -8,6 +8,7 @@ import {StorySharedModule} from '../story/story-shared.module';
 import {MainPrivacyPolicyComponent} from './pages/privacy-policy/privacy-policy.component';
 import {MainFaqComponent} from './pages/faq/faq.component';
 import {LayoutModule} from '../../core/layout.module';
+import {MainTransparencyComponent} from './pages/transparency/transparency.component';
 
 @NgModule({
   declarations: [
@@ -16,6 +17,7 @@ import {LayoutModule} from '../../core/layout.module';
     MainTermsOfServiceComponent,
     MainPrivacyPolicyComponent,
     MainFaqComponent,
+    MainTransparencyComponent,
   ],
   imports: [
     MainRoutingModule,

--- a/honestcash-v2/src/app/main/main.module.ts
+++ b/honestcash-v2/src/app/main/main.module.ts
@@ -9,11 +9,13 @@ import {MainPrivacyPolicyComponent} from './pages/privacy-policy/privacy-policy.
 import {MainFaqComponent} from './pages/faq/faq.component';
 import {LayoutModule} from '../../core/layout.module';
 import {MainTransparencyComponent} from './pages/transparency/transparency.component';
+import {MainAboutHonestCashComponent} from './pages/about-honest-cash/about-honest-cash.component';
 
 @NgModule({
   declarations: [
     MainContainerComponent,
     MainAboutComponent,
+    MainAboutHonestCashComponent,
     MainTermsOfServiceComponent,
     MainPrivacyPolicyComponent,
     MainFaqComponent,

--- a/honestcash-v2/src/app/main/pages/about-honest-cash/about-honest-cash.component.html
+++ b/honestcash-v2/src/app/main/pages/about-honest-cash/about-honest-cash.component.html
@@ -1,0 +1,13 @@
+<div class="card-body">
+  <div *ngIf="isLoading" class="row">
+    <div class="col text-center">
+      <shared-loading-indicator></shared-loading-indicator>
+    </div>
+  </div>
+  <div *ngIf="!isLoading" class="row">
+    <div class="col">
+      <story-title *ngIf="story.title"></story-title>
+      <story-body *ngIf="story.body"></story-body>
+    </div>
+  </div>
+</div>

--- a/honestcash-v2/src/app/main/pages/about-honest-cash/about-honest-cash.component.html
+++ b/honestcash-v2/src/app/main/pages/about-honest-cash/about-honest-cash.component.html
@@ -6,8 +6,19 @@
   </div>
   <div *ngIf="!isLoading" class="row">
     <div class="col">
-      <story-title *ngIf="story.title"></story-title>
-      <story-body *ngIf="story.body"></story-body>
+      <story-response-details *ngIf="story.parentPost"></story-response-details>
+      <story-title></story-title>
+      <story-details></story-details>
+      <story-body *ngIf="!story.hasPaidSection"></story-body>
+      <story-locked-body *ngIf="story.hasPaidSection"></story-locked-body>
+      <story-author></story-author>
+      <story-actions [story]="story"></story-actions>
+      <hr class="my-5">
+      <story-upvotes></story-upvotes>
+      <hr class="my-5" *ngIf="story.hasPaidSection">
+      <story-unlocks *ngIf="story.hasPaidSection"></story-unlocks>
+      <hr class="my-5">
+      <story-comments></story-comments>
     </div>
   </div>
 </div>

--- a/honestcash-v2/src/app/main/pages/about-honest-cash/about-honest-cash.component.scss
+++ b/honestcash-v2/src/app/main/pages/about-honest-cash/about-honest-cash.component.scss
@@ -1,0 +1,21 @@
+@import '../../../../styles';
+
+.container {
+  height: 100%;
+  align-content: center;
+}
+
+:host {
+  width: 800px;
+  @include background-opacity($white, 5);
+
+  ::ng-deep {
+    img {
+      max-width: 100%;
+    }
+  }
+}
+
+ul.list-group > li.list-group-item {
+  @include background-opacity($white, 5);
+}

--- a/honestcash-v2/src/app/main/pages/about-honest-cash/about-honest-cash.component.ts
+++ b/honestcash-v2/src/app/main/pages/about-honest-cash/about-honest-cash.component.ts
@@ -1,0 +1,40 @@
+import {Component, HostBinding, OnDestroy, OnInit} from '@angular/core';
+import Story from '../../../story/models/story';
+import {Observable, Subscription} from 'rxjs';
+import {StoryState} from '../../../story/store/story.state';
+import {Store} from '@ngrx/store';
+import {AppStates, selectStoryState} from '../../../app.states';
+import {StoryLoad} from '../../../story/store/story.actions';
+
+
+@Component({
+  selector: 'main-page-about-honest-cash',
+  templateUrl: './about-honest-cash.component.html',
+  styleUrls: ['./about-honest-cash.component.scss']
+})
+export class MainAboutHonestCashComponent implements OnInit, OnDestroy {
+  @HostBinding('class') public class = 'm-auto';
+  public story: Story;
+  public story$: Observable<StoryState>;
+  public storySub: Subscription;
+  public isLoading = true;
+  constructor(
+    private store: Store<AppStates>,
+  ) {
+    this.story$ = this.store.select(selectStoryState);
+  }
+
+  public ngOnInit() {
+    this.store.dispatch(new StoryLoad(56));
+    this.storySub = this.story$.subscribe((storyState: StoryState) => {
+      this.story = storyState.story;
+      this.isLoading = storyState.isLoading;
+    });
+  }
+
+  public ngOnDestroy() {
+    if (this.storySub) {
+      this.storySub.unsubscribe();
+    }
+  }
+}

--- a/honestcash-v2/src/app/main/pages/about/about.component.ts
+++ b/honestcash-v2/src/app/main/pages/about/about.component.ts
@@ -7,5 +7,5 @@ import { Component, HostBinding } from '@angular/core';
   styleUrls: ['./about.component.scss']
 })
 export class MainAboutComponent {
-  @HostBinding('class') public class = 'card m-auto';
+  @HostBinding('class') public class = 'm-auto';
 }

--- a/honestcash-v2/src/app/main/pages/faq/faq.component.html
+++ b/honestcash-v2/src/app/main/pages/faq/faq.component.html
@@ -6,8 +6,19 @@
   </div>
   <div *ngIf="!isLoading" class="row">
     <div class="col">
-      <story-title *ngIf="story.title"></story-title>
-      <story-body *ngIf="story.body"></story-body>
+      <story-response-details *ngIf="story.parentPost"></story-response-details>
+      <story-title></story-title>
+      <story-details></story-details>
+      <story-body *ngIf="!story.hasPaidSection"></story-body>
+      <story-locked-body *ngIf="story.hasPaidSection"></story-locked-body>
+      <story-author></story-author>
+      <story-actions [story]="story"></story-actions>
+      <hr class="my-5">
+      <story-upvotes></story-upvotes>
+      <hr class="my-5" *ngIf="story.hasPaidSection">
+      <story-unlocks *ngIf="story.hasPaidSection"></story-unlocks>
+      <hr class="my-5">
+      <story-comments></story-comments>
     </div>
   </div>
 </div>

--- a/honestcash-v2/src/app/main/pages/faq/faq.component.ts
+++ b/honestcash-v2/src/app/main/pages/faq/faq.component.ts
@@ -13,7 +13,7 @@ import {StoryLoad} from '../../../story/store/story.actions';
   styleUrls: ['./faq.component.scss']
 })
 export class MainFaqComponent implements OnInit, OnDestroy {
-  @HostBinding('class') public class = 'card m-auto';
+  @HostBinding('class') public class = 'm-auto';
   public story: Story;
   public story$: Observable<StoryState>;
   public storySub: Subscription;
@@ -28,10 +28,7 @@ export class MainFaqComponent implements OnInit, OnDestroy {
     this.store.dispatch(new StoryLoad(57));
     this.storySub = this.story$.subscribe((storyState: StoryState) => {
       this.story = storyState.story;
-
-      if (this.story && this.story.title) {
-        this.isLoading = false;
-      }
+      this.isLoading = storyState.isLoading;
     });
   }
 

--- a/honestcash-v2/src/app/main/pages/privacy-policy/privacy-policy.component.html
+++ b/honestcash-v2/src/app/main/pages/privacy-policy/privacy-policy.component.html
@@ -6,8 +6,19 @@
   </div>
   <div *ngIf="!isLoading" class="row">
     <div class="col">
-      <story-title *ngIf="story.title"></story-title>
-      <story-body *ngIf="story.body"></story-body>
+      <story-response-details *ngIf="story.parentPost"></story-response-details>
+      <story-title></story-title>
+      <story-details></story-details>
+      <story-body *ngIf="!story.hasPaidSection"></story-body>
+      <story-locked-body *ngIf="story.hasPaidSection"></story-locked-body>
+      <story-author></story-author>
+      <story-actions [story]="story"></story-actions>
+      <hr class="my-5">
+      <story-upvotes></story-upvotes>
+      <hr class="my-5" *ngIf="story.hasPaidSection">
+      <story-unlocks *ngIf="story.hasPaidSection"></story-unlocks>
+      <hr class="my-5">
+      <story-comments></story-comments>
     </div>
   </div>
 </div>

--- a/honestcash-v2/src/app/main/pages/terms-of-service/terms-of-service.component.html
+++ b/honestcash-v2/src/app/main/pages/terms-of-service/terms-of-service.component.html
@@ -6,8 +6,19 @@
   </div>
   <div *ngIf="!isLoading" class="row">
     <div class="col">
-      <story-title *ngIf="story.title"></story-title>
-      <story-body *ngIf="story.body"></story-body>
+      <story-response-details *ngIf="story.parentPost"></story-response-details>
+      <story-title></story-title>
+      <story-details></story-details>
+      <story-body *ngIf="!story.hasPaidSection"></story-body>
+      <story-locked-body *ngIf="story.hasPaidSection"></story-locked-body>
+      <story-author></story-author>
+      <story-actions [story]="story"></story-actions>
+      <hr class="my-5">
+      <story-upvotes></story-upvotes>
+      <hr class="my-5" *ngIf="story.hasPaidSection">
+      <story-unlocks *ngIf="story.hasPaidSection"></story-unlocks>
+      <hr class="my-5">
+      <story-comments></story-comments>
     </div>
   </div>
 </div>

--- a/honestcash-v2/src/app/main/pages/terms-of-service/terms-of-service.component.ts
+++ b/honestcash-v2/src/app/main/pages/terms-of-service/terms-of-service.component.ts
@@ -13,7 +13,7 @@ import {StoryLoad} from '../../../story/store/story.actions';
   styleUrls: ['./terms-of-service.component.scss']
 })
 export class MainTermsOfServiceComponent implements OnInit, OnDestroy {
-  @HostBinding('class') public class = 'card m-auto';
+  @HostBinding('class') public class = 'm-auto';
   public story: Story;
   public story$: Observable<StoryState>;
   public storySub: Subscription;
@@ -28,10 +28,7 @@ export class MainTermsOfServiceComponent implements OnInit, OnDestroy {
     this.store.dispatch(new StoryLoad(124));
     this.storySub = this.story$.subscribe((storyState: StoryState) => {
       this.story = storyState.story;
-
-      if (this.story && this.story.title) {
-        this.isLoading = false;
-      }
+      this.isLoading = storyState.isLoading;
     });
   }
 

--- a/honestcash-v2/src/app/main/pages/transparency/transparency.component.html
+++ b/honestcash-v2/src/app/main/pages/transparency/transparency.component.html
@@ -1,0 +1,13 @@
+<div class="card-body">
+  <div *ngIf="isLoading" class="row">
+    <div class="col text-center">
+      <shared-loading-indicator></shared-loading-indicator>
+    </div>
+  </div>
+  <div *ngIf="!isLoading" class="row">
+    <div class="col">
+      <story-title *ngIf="story.title"></story-title>
+      <story-body *ngIf="story.body"></story-body>
+    </div>
+  </div>
+</div>

--- a/honestcash-v2/src/app/main/pages/transparency/transparency.component.html
+++ b/honestcash-v2/src/app/main/pages/transparency/transparency.component.html
@@ -6,8 +6,19 @@
   </div>
   <div *ngIf="!isLoading" class="row">
     <div class="col">
-      <story-title *ngIf="story.title"></story-title>
-      <story-body *ngIf="story.body"></story-body>
+      <story-response-details *ngIf="story.parentPost"></story-response-details>
+      <story-title></story-title>
+      <story-details></story-details>
+      <story-body *ngIf="!story.hasPaidSection"></story-body>
+      <story-locked-body *ngIf="story.hasPaidSection"></story-locked-body>
+      <story-author></story-author>
+      <story-actions [story]="story"></story-actions>
+      <hr class="my-5">
+      <story-upvotes></story-upvotes>
+      <hr class="my-5" *ngIf="story.hasPaidSection">
+      <story-unlocks *ngIf="story.hasPaidSection"></story-unlocks>
+      <hr class="my-5">
+      <story-comments></story-comments>
     </div>
   </div>
 </div>

--- a/honestcash-v2/src/app/main/pages/transparency/transparency.component.scss
+++ b/honestcash-v2/src/app/main/pages/transparency/transparency.component.scss
@@ -10,11 +10,8 @@
   @include background-opacity($white, 5);
 
   ::ng-deep {
-    figure {
-      text-align: center;
-    }
     img {
-      max-width: 50% !important;
+      max-width: 100%;
     }
   }
 }

--- a/honestcash-v2/src/app/main/pages/transparency/transparency.component.ts
+++ b/honestcash-v2/src/app/main/pages/transparency/transparency.component.ts
@@ -8,11 +8,11 @@ import {StoryLoad} from '../../../story/store/story.actions';
 
 
 @Component({
-  selector: 'main-page-terms-of-service',
-  templateUrl: './privacy-policy.component.html',
-  styleUrls: ['./privacy-policy.component.scss']
+  selector: 'main-page-transparency',
+  templateUrl: './transparency.component.html',
+  styleUrls: ['./transparency.component.scss']
 })
-export class MainPrivacyPolicyComponent implements OnInit, OnDestroy {
+export class MainTransparencyComponent implements OnInit, OnDestroy {
   @HostBinding('class') public class = 'm-auto';
   public story: Story;
   public story$: Observable<StoryState>;
@@ -25,7 +25,7 @@ export class MainPrivacyPolicyComponent implements OnInit, OnDestroy {
   }
 
   public ngOnInit() {
-    this.store.dispatch(new StoryLoad(133));
+    this.store.dispatch(new StoryLoad(129));
     this.storySub = this.story$.subscribe((storyState: StoryState) => {
       this.story = storyState.story;
       this.isLoading = storyState.isLoading;

--- a/honestcash-v2/src/app/story/store/story.reducer.ts
+++ b/honestcash-v2/src/app/story/store/story.reducer.ts
@@ -18,6 +18,12 @@ const appendShareUrls = (story: Story) => {
 
 export function reducer(state = initialStoryState, action: All): StoryState {
   switch (action.type) {
+    case StoryActionTypes.STORY_LOAD: {
+      return {
+        ...state,
+        isLoading: true,
+      };
+    }
     case StoryActionTypes.STORY_LOAD_SUCCESS: {
       const story = appendShareUrls(action.payload);
       return {

--- a/honestcash-v2/src/app/story/story-shared.module.ts
+++ b/honestcash-v2/src/app/story/story-shared.module.ts
@@ -6,12 +6,53 @@ import {StoryCommentButtonComponent} from './components/comment-button/comment-b
 import {StoryService} from './services/story.service';
 import {StoryEffects} from './store/story.effects';
 import {SharedComponentsModule} from '../../core/shared-components.module';
+import {StoryUpvotesComponent} from './components/upvotes/story-upvotes.component';
+import {StoryUnlocksComponent} from './components/unlocks/story-unlocks.component';
+import {StoryCommentsComponent} from './components/comments/story-comments.component';
+import {StoryCommentCardComponent} from './components/comment-card/story-comment-card.component';
+import {StoryCommentEditorComponent} from './components/comment-editor/story-comment-editor.component';
+import {StoryDetailsComponent} from './components/details/story-details.component';
+import {StoryTagsComponent} from './components/tags/story-tags.component';
+import {StoryUpvoteButtonComponent} from './components/upvote-button/story-upvote-button.component';
+import {StoryShareButtonsComponent} from './components/share-buttons/story-share-buttons.component';
+import {StoryActionsComponent} from './components/actions/story-actions.component';
+import {StoryAuthorComponent} from './components/author/story-author.component';
+import {StoryPayerBadgeComponent} from './components/payer-badge/story-payer-badge.component';
+import {StoryPaywallCallToActionComponent} from './components/paywall-call-to-action/paywall-call-to-action.component';
+import {StoryLockedBodyComponent} from './components/locked-body/locked-body.component';
+import {StoryUnlockButtonComponent} from './components/unlock-button/unlock-button.component';
+import {StoryCommentCardActionsComponent} from './components/comment-card-actions/comment-card-actions.component';
+import {StoryCommentCardBodyComponent} from './components/comment-card-body/story-comment-card-body.component';
+import {StoryCommentCardHeaderComponent} from './components/comment-card-header/story-comment-card-header.component';
+import {StoryResponseDetailsComponent} from './components/response-details/response-details.component';
+import {OrderModule} from 'ngx-order-pipe';
+import {WalletSharedModule} from '../wallet/wallet-shared.module';
+import {UserSharedModule} from '../user/user-shared.module';
 
 @NgModule({
   declarations: [
     StoryBodyComponent,
     StoryTitleComponent,
     StoryCommentButtonComponent,
+    StoryUpvotesComponent,
+    StoryUnlocksComponent,
+    StoryCommentsComponent,
+    StoryCommentCardComponent,
+    StoryCommentEditorComponent,
+    StoryDetailsComponent,
+    StoryTagsComponent,
+    StoryUpvoteButtonComponent,
+    StoryShareButtonsComponent,
+    StoryActionsComponent,
+    StoryAuthorComponent,
+    StoryPayerBadgeComponent,
+    StoryPaywallCallToActionComponent,
+    StoryLockedBodyComponent,
+    StoryUnlockButtonComponent,
+    StoryCommentCardActionsComponent,
+    StoryCommentCardBodyComponent,
+    StoryCommentCardHeaderComponent,
+    StoryResponseDetailsComponent,
   ],
   providers: [
     StoryService,
@@ -20,6 +61,9 @@ import {SharedComponentsModule} from '../../core/shared-components.module';
   imports: [
     SharedModule,
     SharedComponentsModule,
+    OrderModule,
+    WalletSharedModule,
+    UserSharedModule,
   ],
   exports: [
     SharedModule,
@@ -27,6 +71,25 @@ import {SharedComponentsModule} from '../../core/shared-components.module';
     StoryBodyComponent,
     StoryTitleComponent,
     StoryCommentButtonComponent,
+    StoryUpvotesComponent,
+    StoryUnlocksComponent,
+    StoryCommentsComponent,
+    StoryCommentCardComponent,
+    StoryCommentEditorComponent,
+    StoryDetailsComponent,
+    StoryTagsComponent,
+    StoryUpvoteButtonComponent,
+    StoryShareButtonsComponent,
+    StoryActionsComponent,
+    StoryAuthorComponent,
+    StoryPayerBadgeComponent,
+    StoryPaywallCallToActionComponent,
+    StoryLockedBodyComponent,
+    StoryUnlockButtonComponent,
+    StoryCommentCardActionsComponent,
+    StoryCommentCardBodyComponent,
+    StoryCommentCardHeaderComponent,
+    StoryResponseDetailsComponent,
   ],
 })
 export class StorySharedModule {

--- a/honestcash-v2/src/app/story/story.module.ts
+++ b/honestcash-v2/src/app/story/story.module.ts
@@ -2,69 +2,22 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {StoryRoutingModule} from './story-routing.module';
-import {StoryUpvotesComponent} from './components/upvotes/story-upvotes.component';
-import {StoryAuthorComponent} from './components/author/story-author.component';
-import {StoryCommentEditorComponent} from './components/comment-editor/story-comment-editor.component';
-import {StoryPayerBadgeComponent} from './components/payer-badge/story-payer-badge.component';
-import {StoryUpvoteButtonComponent} from './components/upvote-button/story-upvote-button.component';
-import {StoryTagsComponent} from './components/tags/story-tags.component';
-import {StoryUnlocksComponent} from './components/unlocks/story-unlocks.component';
-import {StoryDetailsComponent} from './components/details/story-details.component';
-import {StoryCommentCardComponent} from './components/comment-card/story-comment-card.component';
-import {StoryCommentsComponent} from './components/comments/story-comments.component';
 import {SharedModule} from '../../core/shared.module';
-import {StoryActionsComponent} from './components/actions/story-actions.component';
-import {StoryShareButtonsComponent} from './components/share-buttons/story-share-buttons.component';
-import {StoryPaywallCallToActionComponent} from './components/paywall-call-to-action/paywall-call-to-action.component';
-import {StoryLockedBodyComponent} from './components/locked-body/locked-body.component';
 import {StoryComponent} from './story.component';
-import {StoryUnlockButtonComponent} from './components/unlock-button/unlock-button.component';
-import {StoryCommentCardActionsComponent} from './components/comment-card-actions/comment-card-actions.component';
-import {StoryCommentCardBodyComponent} from './components/comment-card-body/story-comment-card-body.component';
-import {StoryCommentCardHeaderComponent} from './components/comment-card-header/story-comment-card-header.component';
-import {StoryResponseDetailsComponent} from './components/response-details/response-details.component';
-import {EffectsModule} from '@ngrx/effects';
-import {StoryEffects} from './store/story.effects';
-import {SharedComponentsModule} from '../../core/shared-components.module';
 import {StorySharedModule} from './story-shared.module';
 import {LayoutModule} from '../../core/layout.module';
-import {UserSharedModule} from '../user/user-shared.module';
-import {WalletSharedModule} from '../wallet/wallet-shared.module';
-import {OrderModule} from 'ngx-order-pipe';
 
 @NgModule({
   declarations: [
     StoryComponent,
-    StoryUpvotesComponent,
-    StoryUnlocksComponent,
-    StoryCommentsComponent,
-    StoryCommentCardComponent,
-    StoryCommentEditorComponent,
-    StoryDetailsComponent,
-    StoryTagsComponent,
-    StoryUpvoteButtonComponent,
-    StoryShareButtonsComponent,
-    StoryActionsComponent,
-    StoryAuthorComponent,
-    StoryPayerBadgeComponent,
-    StoryPaywallCallToActionComponent,
-    StoryLockedBodyComponent,
-    StoryUnlockButtonComponent,
-    StoryCommentCardActionsComponent,
-    StoryCommentCardBodyComponent,
-    StoryCommentCardHeaderComponent,
-    StoryResponseDetailsComponent,
   ],
   imports: [
     StoryRoutingModule,
     StorySharedModule,
     CommonModule,
-    WalletSharedModule,
-    UserSharedModule,
     LayoutModule,
     CommonModule,
     SharedModule,
-    OrderModule,
   ],
   bootstrap: [StoryComponent]
 })

--- a/honestcash-v2/src/app/user/components/profile-menu/profile-menu.component.html
+++ b/honestcash-v2/src/app/user/components/profile-menu/profile-menu.component.html
@@ -3,15 +3,15 @@
     <shared-avatar [src]="user.imageUrl"></shared-avatar>
     <user-balance></user-balance>
   </a>
-  <div ngbDropdownMenu aria-labelledby="user-dropdown">
-    <button class="dropdown-item" (click)="goTo('profile')" translate>my profile</button>
-    <button class="dropdown-item" (click)="goTo('posts')" translate>my posts</button>
-    <button class="dropdown-item" (click)="goTo('wallet')" translate>my wallet</button>
+  <div id="user-dropdown-list" ngbDropdownMenu aria-labelledby="user-dropdown">
+    <a class="dropdown-item" (click)="goTo('profile')">my profile</a>
+    <a class="dropdown-item" (click)="goTo('posts')">my posts</a>
+    <a class="dropdown-item" (click)="goTo('wallet')">my wallet</a>
     <div class="dropdown-divider"></div>
-    <button class="dropdown-item" (click)="goTo('help')" translate>help</button>
-    <button class="dropdown-item" (click)="goTo('terms-of-service')" translate>terms of service</button>
-    <button class="dropdown-item" (click)="goTo('privacy-policy')" translate>privacy policy</button>
+    <a class="dropdown-item" [routerLink]="['/frequently-asked-questions']">help</a>
+    <a class="dropdown-item"  [routerLink]="['/terms-of-service']">terms of service</a>
+    <a class="dropdown-item"  [routerLink]="['/privacy-policy']">privacy policy</a>
     <div class="dropdown-divider"></div>
-    <button class="dropdown-item" (click)="logout()" translate>Logout</button>
+    <a class="dropdown-item" (click)="logout()">Logout</a>
   </div>
 </div>

--- a/honestcash-v2/src/app/wallet/services/wallet.service.spec.ts
+++ b/honestcash-v2/src/app/wallet/services/wallet.service.spec.ts
@@ -159,23 +159,30 @@ describe('WalletService', () => {
     });
 
     describe('createWallet should', () => {
+
+      const realWalletMocks = {
+        mnemonic: 'runway bleak method trim length fame gun coral scrap pizza frog place',
+        mnemonicEncrypted: 'U2FsdGVkX18wTELTnxkgeZypULgSB+cPakb91vE89RNqdTjuRO+C5gIwFF4Pdefl40h8ZlbEhX9NqZheiP1knx9qj6u1Eh31MENN/WJTYI4nSRw3l+4t+p9p0BbGxWXs',
+        password: '12345678'
+      };
       it('return a wallet when mnemonicEncrypted and password is provided', (done) => {
+
         scriptService.loadScript(simpleBitcoinWalletAssetPath).subscribe(() => {
-          const wallet = walletService.createWallet(undefined, 'asdfasdf', 'asdfasdf');
+          const wallet = walletService.createWallet(undefined, realWalletMocks.mnemonicEncrypted, realWalletMocks.password);
           expect(wallet).toBeDefined();
           done();
         });
       });
       it('return a wallet when mnemonic is provided', (done) => {
         scriptService.loadScript(simpleBitcoinWalletAssetPath).subscribe(() => {
-          const wallet = walletService.createWallet('asdfasdf');
+          const wallet = walletService.createWallet(realWalletMocks.mnemonic);
           expect(wallet).toBeDefined();
           done();
         });
       });
       it('return a wallet when password', (done) => {
         scriptService.loadScript(simpleBitcoinWalletAssetPath).subscribe(() => {
-          const wallet = walletService.createWallet(undefined, undefined, 'asdfasdf');
+          const wallet = walletService.createWallet(undefined, undefined, realWalletMocks.password);
           expect(wallet).toBeDefined();
           done();
         });

--- a/public/app.html
+++ b/public/app.html
@@ -69,7 +69,7 @@
 					<button class="btn btn-default" ui-sref="wallet.create()">Connect your Bitcoin Cash wallet</button>
 
 					<div class="form-group">
-						<h4>... or tip from any other Bitcoin Cash wallet. What's <a href="https://honest.cash/honest_cash/frequently-asked-questions">Bitcoin Cash</a>?</h4>
+						<h4>... or tip from any other Bitcoin Cash wallet. What's <a target="_self" href="/frequently-asked-questions">Bitcoin Cash</a>?</h4>
 
 						<input readonly class="form-control" id="bchTippingAddress">
 
@@ -246,7 +246,7 @@
 	<script type="text/javascript" src="/assets/libs/simple-bitcoin-wallet.min.js"></script>
 
   <script type="text/javascript" src="/js/app.js"></script>
-  
+
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-71873199-5"></script>
   <script>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> 
-      
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
         <url>
-          <loc>https://honest.cash/honest_cash/about-honest-cash</loc>
+          <loc>https://honest.cash/about-honest-cash</loc>
           <lastmod>
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
-          <loc>https://honest.cash/honest_cash/frequently-asked-questions</loc>
+          <loc>https://honest.cash/frequently-asked-questions</loc>
           <lastmod>
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/new-on-honest-cash-create-responses-to-other-stories-58</loc>
@@ -23,7 +23,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/negative-kelvin-temperatures-in-lasers-61</loc>
@@ -31,7 +31,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tom/hello-world-62</loc>
@@ -39,7 +39,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kevin/hello-world-67</loc>
@@ -47,7 +47,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/poetry-by-an-african-sons-of-kwazulu-68</loc>
@@ -55,7 +55,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/crypt05ingh/ek-onkar-70</loc>
@@ -63,7 +63,7 @@
             2018-12-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Posternut/a-cypherpunks-manifesto-71</loc>
@@ -71,7 +71,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BrianXV/introduction-72</loc>
@@ -79,7 +79,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/ridedonkeys-blog-launchrelaunch-test-73</loc>
@@ -87,7 +87,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/fterward/a-whisper-76</loc>
@@ -95,7 +95,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/LizbethAlviarez/mi-presentacion-en-honestcash-77</loc>
@@ -103,7 +103,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/at-the-birth-80</loc>
@@ -111,7 +111,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emergent_reasons/dollar5700000-in-pending-fees-81</loc>
@@ -119,7 +119,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TheOneLaw/ascending-the-credibility-spectrum-82</loc>
@@ -127,7 +127,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Thecryptosid/hey-guys-just-joined-honest-cash-here-are-my-thoughts-83</loc>
@@ -135,7 +135,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cdoubleo/new-beginnings-and-the-nature-of-reality-84</loc>
@@ -143,7 +143,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cdoubleo/contact-details-85</loc>
@@ -151,7 +151,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Aldin_SXR/an-honest-social-media-network-86</loc>
@@ -159,7 +159,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dagur/lets-talk-spec-introduction-88</loc>
@@ -167,7 +167,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dagur/lets-talk-spec-1-asymmetric-moving-maxblocksize-based-on-median-block-size-89</loc>
@@ -175,7 +175,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dagur/lets-talk-spec-2-more-opcode-primitives-90</loc>
@@ -183,7 +183,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dagur/lets-talk-spec-3-remove-the-transaction-undersize-limit-91</loc>
@@ -191,7 +191,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/isaacmorehouse/why-i-choose-freedom-95</loc>
@@ -199,7 +199,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/sobrevivimos-pero-debemos-permanecer-vigilantes-96</loc>
@@ -207,7 +207,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Lumis/chicken-soup-97</loc>
@@ -215,7 +215,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/illegal-code-102</loc>
@@ -223,7 +223,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/can-written-shorthand-speed-up-your-notetaking-104</loc>
@@ -231,7 +231,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/should-more-learn-sign-language-to-communicate-in-loud-or-quiet-spaces-105</loc>
@@ -239,7 +239,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/im-thinking-106</loc>
@@ -247,7 +247,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/matewo/honest-cash-upvoting-algorithm-107</loc>
@@ -255,7 +255,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/technologies-for-democratizing-power-108</loc>
@@ -263,7 +263,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/new-on-honestcash-connect-your-bitcoin-wallet-and-give-tips-directly-to-writers-109</loc>
@@ -271,7 +271,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/reizu/making-double-spending-0-conf-with-bitcoin-sv-117</loc>
@@ -279,7 +279,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/new-on-honest-cash-code-blocks-and-inline-code-122</loc>
@@ -287,7 +287,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/new-on-honest-cash-custom-hd-derivation-paths-123</loc>
@@ -295,7 +295,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/honest-cash-terms-of-service-124</loc>
@@ -303,7 +303,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/new-on-honest-cash-personalise-what-you-see-on-honest-cash-125</loc>
@@ -311,7 +311,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/new-on-honest-cash-get-paid-for-upvoting-and-promoting-good-content-early-on-127</loc>
@@ -319,7 +319,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/coming-soon-bitcoin-authentification-on-honest-cash-work-in-progress-128</loc>
@@ -327,7 +327,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/honest-cash-transparency-report-and-warrant-canary-129</loc>
@@ -335,7 +335,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chicken/how-to-safely-split-bch-and-bsv-coins-using-electron-cash-with-pictures-130</loc>
@@ -343,7 +343,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/honestcash-wallet-update-132</loc>
@@ -351,7 +351,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/honestcash-privacy-policy</loc>
@@ -359,7 +359,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/how-to-import-your-honest-wallet-into-electron-cash-134</loc>
@@ -367,7 +367,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/update-upvote-transactions-stored-on-chain-and-open-call-to-bitcoin-explorers-135</loc>
@@ -375,7 +375,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/honest-cash-just-became-more-transparent-137</loc>
@@ -383,7 +383,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/evolution-of-language-140</loc>
@@ -391,7 +391,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Toomuch72/op_return-maybe-143</loc>
@@ -399,7 +399,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoIndia/hivr-join-the-open-beta-now-and-get-a-dollar1-gift-from-us-145</loc>
@@ -407,7 +407,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/alrashel/early-bird-147</loc>
@@ -415,7 +415,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/my-last-free-post-on-honest-cash-148</loc>
@@ -423,7 +423,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/vandres/happy-to-be-here-150</loc>
@@ -431,7 +431,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/improving-honest-short-responses-on-memocash-and-subforums-151</loc>
@@ -439,7 +439,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AD1AD/the-potentially-bright-future-of-contentious-chain-splits-without-replay-protection-152</loc>
@@ -447,7 +447,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/limitless-peace-manifesto-2018-153</loc>
@@ -455,7 +455,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RARK/quick-tip-heres-how-ive-maintained-my-digital-wealth-during-bear-season-155</loc>
@@ -463,7 +463,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RARK/how-to-surf-through-the-waves-of-crypto-volatility-156</loc>
@@ -471,7 +471,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptonomoist/bitcoin-technical-analysis-158</loc>
@@ -479,7 +479,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/hey-hey-hey-welcome-me-this-is-oodeyaa-here-from-india-160</loc>
@@ -487,7 +487,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/avoid-arguments-for-a-healthier-relationship-163</loc>
@@ -495,7 +495,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Coolzero/-165</loc>
@@ -503,7 +503,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/david/what-i-believe-in-166</loc>
@@ -511,7 +511,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/amazingvijay/is-it-profitable-to-set-up-a-btc-miner-168</loc>
@@ -519,7 +519,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/amazingvijay/might-need-some-update-169</loc>
@@ -527,7 +527,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chicken/announcment-170</loc>
@@ -535,7 +535,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/pein_sama/spending-constraints-with-op_checkdatasig-172</loc>
@@ -543,7 +543,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/when-bottom-when-moon-174</loc>
@@ -551,7 +551,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptosignal/bchsv-has-entered-the-top-10-on-coinmarketcap-175</loc>
@@ -559,7 +559,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/pein_sama/the-most-hilarious-yet-successful-scam-mail-ive-ever-seen-177</loc>
@@ -567,7 +567,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jammasterc/good-article-thanks-178</loc>
@@ -575,7 +575,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AD1AD/a-user-specific-vote-weight-system-to-combat-well-funded-meddlers-179</loc>
@@ -583,7 +583,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/freecash-a-future-role-for-bitcoin-cash-182</loc>
@@ -591,7 +591,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/bitcoins-absolute-price-floor-184</loc>
@@ -599,7 +599,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/suicide-rates-185</loc>
@@ -607,7 +607,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nicewoody69/the-candles-a-poetic-love-life-and-death-story-186</loc>
@@ -615,7 +615,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nicewoody69/nature-a-phenom-by-design-a-poetic-piece-187</loc>
@@ -623,7 +623,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/first-post-188</loc>
@@ -631,7 +631,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/pneumonic-frustration-and-relaxation-189</loc>
@@ -639,7 +639,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/linking-and-following-by-responding-190</loc>
@@ -647,7 +647,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/work-as-your-footprints-can-last-for-centuries-192</loc>
@@ -655,7 +655,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Affenzwirbler/hello-world-193</loc>
@@ -663,7 +663,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/sometimes-its-right-to-be-an-argumentative-bastard-194</loc>
@@ -671,7 +671,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Affenzwirbler/the-next-crises-the-next-big-chance-195</loc>
@@ -679,7 +679,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Wecx/my-response-to-_unwriter-196</loc>
@@ -687,7 +687,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/framore/another-site-200</loc>
@@ -695,7 +695,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCom/taking-the-leap-didi-of-the-bitcoin-family-203</loc>
@@ -703,7 +703,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/who-is-responsible-for-our-bad-days-and-miseries-204</loc>
@@ -711,7 +711,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BTCcom/how-do-bitcoin-transactions-work-205</loc>
@@ -719,7 +719,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/honestcash-is-somewhat-ironic-206</loc>
@@ -727,7 +727,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/putting-energy-here-bch-ideological-wars-207</loc>
@@ -735,7 +735,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/be-vigilant-for-honestcash-to-stay-honest-210</loc>
@@ -743,7 +743,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/why-should-you-upvote-the-good-content-now-211</loc>
@@ -751,7 +751,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yoonski/my-first-post-215</loc>
@@ -759,7 +759,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jsabastine/food-for-tought-216</loc>
@@ -767,7 +767,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tom/deep-reorgs-protection-217</loc>
@@ -775,7 +775,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/bitcoin-cash-101-coins-and-privacy-220</loc>
@@ -783,7 +783,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/community-moderated-honesty-221</loc>
@@ -791,7 +791,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/a-second-chance-223</loc>
@@ -799,7 +799,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/honestcash-and-self-serve-advertising-224</loc>
@@ -807,7 +807,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/psychiatric-units-225</loc>
@@ -815,7 +815,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BTCcom/the-btccom-wallet-offers-replay-protection-and-a-bsv-extraction-tool-for-its-users-226</loc>
@@ -823,7 +823,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Coolzero/-227</loc>
@@ -831,7 +831,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/feel-the-blessings-of-god-229</loc>
@@ -839,7 +839,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Madstudios/indecision-may-or-may-not-be-my-problem-230</loc>
@@ -847,7 +847,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Madstudios/bitcoin-believer-231</loc>
@@ -855,7 +855,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jsabastine/hello-world-my-first-real-post-233</loc>
@@ -863,7 +863,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jsabastine/dj-khaled-and-the-boxing-champion-floyd-mayweather-has-been-penalised-by-the-sec-234</loc>
@@ -871,7 +871,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/lets-start-the-journey-of-success-again-235</loc>
@@ -879,7 +879,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCom/this-week-in-bitcoin-sec-speaks-malicious-code-russian-miners-snowden-236</loc>
@@ -887,7 +887,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darwin/nasty-or-nice-237</loc>
@@ -895,7 +895,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darwin/bitcoin-cash-development-video-meeting-238</loc>
@@ -903,7 +903,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/stoked-to-see-bitcoincom-on-honestcash-239</loc>
@@ -911,7 +911,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Coolzero/-240</loc>
@@ -919,7 +919,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/intel-is-going-to-change-the-game-but-would-it-be-cheap-242</loc>
@@ -927,7 +927,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/richze90/centralized-vs-decentralized-systems-244</loc>
@@ -935,7 +935,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/richze90/no-code-platforms-the-primary-management-tool-of-the-future-245</loc>
@@ -943,7 +943,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/basics-of-arbitrage-in-the-crypto-world-with-bitcoin-examples-246</loc>
@@ -951,7 +951,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/collinenstad/the-great-bitcoin-cash-hashwar-a-tale-of-posturing-and-moving-goalposts-247</loc>
@@ -959,7 +959,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TreeGuyShaman/tonic-zen-accepts-crypto-250</loc>
@@ -967,7 +967,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adnjoo/hello-world-251</loc>
@@ -975,7 +975,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/xSalud/hello-252</loc>
@@ -983,7 +983,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/authentically-compassionate-libertarianism-253</loc>
@@ -991,7 +991,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/is-reincarnation-so-256</loc>
@@ -999,7 +999,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/croviking/living-around-la-have-an-idea-how-to-fix-the-bay-area-commute-258</loc>
@@ -1007,7 +1007,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cdobeso/the-truth-about-change-and-progress-259</loc>
@@ -1015,7 +1015,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/croviking/ultrahack-is-going-crypto-next-spring-and-drone-olympics-260</loc>
@@ -1023,7 +1023,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/its-a-wonderful-life-261</loc>
@@ -1031,7 +1031,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/gezaantal/the-bothersome-man-263</loc>
@@ -1039,7 +1039,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dskloet/side-chains-with-op_checkdatasig-266</loc>
@@ -1047,7 +1047,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/byron/my-screwed-life-267</loc>
@@ -1055,7 +1055,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Money78/great-alternatives-to-moneybutton-so-far-268</loc>
@@ -1063,7 +1063,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/marklundeberg/test-post-123456789-270</loc>
@@ -1071,7 +1071,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Geri/anime-maker-freeware-program-to-create-your-own-anime-273</loc>
@@ -1079,7 +1079,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Geri/bugreports-275</loc>
@@ -1087,7 +1087,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/aelf-innovation-alliance-fueling-blockchain-adaptation-276</loc>
@@ -1095,7 +1095,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/so-you-have-to-have-a-title-even-if-youre-replying-278</loc>
@@ -1103,7 +1103,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/cant-log-in-will-this-post-281</loc>
@@ -1111,7 +1111,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/expiring-contracts-have-no-effect-on-bitcoin-market-282</loc>
@@ -1119,7 +1119,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/nice-catch-2x-tip-for-you-for-being-a-bug-hunter-283</loc>
@@ -1127,7 +1127,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SILENTSAM/tamihi-winter-run-286</loc>
@@ -1135,7 +1135,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/croviking/more-bugreports-287</loc>
@@ -1143,7 +1143,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Uncryptic/learning-how-to-program-web-dev-day-1-289</loc>
@@ -1151,7 +1151,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kylepat94/saying-hi-290</loc>
@@ -1159,7 +1159,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/ready-player-b-291</loc>
@@ -1167,7 +1167,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JakeMcC/earn-crypto-taking-photos-from-your-phone-292</loc>
@@ -1175,7 +1175,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JQnet/mindscom-is-an-open-source-and-distributed-social-networking-service-293</loc>
@@ -1183,7 +1183,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RealBitcoinClub/bitcoin-bike-tour-to-india-295</loc>
@@ -1191,7 +1191,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/being-in-a-psychiatric-unit-296</loc>
@@ -1199,7 +1199,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/where-is-honest-cash-headed-diversity-is-the-bottom-line-but-what-about-images-297</loc>
@@ -1207,7 +1207,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Money78/bitcoin-a-peer-to-peer-electronic-cash-system-by-satoshi-nakamoto-298</loc>
@@ -1215,7 +1215,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/dont-post-for-the-sake-of-posting-tip-300</loc>
@@ -1223,7 +1223,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/usaid-fails-to-find-a-link-between-blockchain-and-success-no-wonder-they-cant-301</loc>
@@ -1231,7 +1231,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/should-involuntary-commitment-be-eliminated-303</loc>
@@ -1239,7 +1239,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/how-to-raise-the-dead-using-science-theoretically-304</loc>
@@ -1247,7 +1247,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/craig-wright-is-not-satoshi-nakamoto-306</loc>
@@ -1255,7 +1255,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/eliminate-involuntary-psychiatric-treatment-and-civil-commitments-307</loc>
@@ -1263,7 +1263,7 @@
             2018-12-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Money78/on-this-day-in-2010-instagram-reaches-1-million-users-308</loc>
@@ -1271,7 +1271,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/dustin-low-lamborghini-raffle-is-giving-away-a-car-for-000057btc-or-238-usd-309</loc>
@@ -1279,7 +1279,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/is-nakamoto-surfacing-after-all-these-years-310</loc>
@@ -1287,7 +1287,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/bitsmart4/four-years-since-p2p-foundation-311</loc>
@@ -1295,7 +1295,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tempo/hello-humans-312</loc>
@@ -1303,7 +1303,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/kariuki/a-note-to-honest-cash-315</loc>
@@ -1311,7 +1311,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/log-in-to-follow-without-the-option-to-log-in-p-317</loc>
@@ -1319,7 +1319,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/this-is-so-frustrating-318</loc>
@@ -1327,7 +1327,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/im-sorry-319</loc>
@@ -1335,7 +1335,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/nvm-its-working-now-d-320</loc>
@@ -1343,7 +1343,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/self-serve-advertising-accepting-cryptocurrencies-322</loc>
@@ -1351,7 +1351,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/100-days-of-honesty-326</loc>
@@ -1359,7 +1359,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/integrable-systems-328</loc>
@@ -1367,7 +1367,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raven/introduction-329</loc>
@@ -1375,7 +1375,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/calisi/blockchain-is-to-bring-the-fashion-supply-chain-to-its-right-way-331</loc>
@@ -1383,7 +1383,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/italian-court-of-highlights-need-for-crypto-regulations-in-the-country-332</loc>
@@ -1391,7 +1391,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/calisi/blockchain-vs-food-waste-333</loc>
@@ -1399,7 +1399,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ChaosElephant/is-it-the-same-watch-334</loc>
@@ -1407,7 +1407,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/guide-to-winning-hackathons-337</loc>
@@ -1415,7 +1415,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Affenzwirbler/comparison-339</loc>
@@ -1423,7 +1423,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/the-first-uncensorable-story-on-honest-cash-340</loc>
@@ -1431,7 +1431,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/why-did-we-create-simple-bitcoin-wallet-at-honest-341</loc>
@@ -1439,7 +1439,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Twist/the-case-for-social-conservatism-342</loc>
@@ -1447,7 +1447,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/the-bch-privacy-game-344</loc>
@@ -1455,7 +1455,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/MobTwo/bitcoin-cash-in-crisis-lies-opportunity-348</loc>
@@ -1463,7 +1463,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lilydavine/how-bitcoin-inspired-me-to-quit-banks-and-go-on-the-run-349</loc>
@@ -1471,7 +1471,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Nohansson/a-bit-bout-my-future-posts-350</loc>
@@ -1479,7 +1479,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/we-must-defeat-aging-352</loc>
@@ -1487,7 +1487,7 @@
             2018-12-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/re-nigerian-hacker-prince-358</loc>
@@ -1495,7 +1495,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emergent_reasons/control-any-bitcoin-cash-bch-wallet-with-electron-cash-360</loc>
@@ -1503,7 +1503,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emergent_reasons/use-a-seed-phrase-from-a-phone-or-other-modern-wallet-in-electron-cash-361</loc>
@@ -1511,7 +1511,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emergent_reasons/use-a-wif-private-key-in-electron-cash-362</loc>
@@ -1519,7 +1519,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emergent_reasons/use-a-hardware-wallet-with-electron-cash-363</loc>
@@ -1527,7 +1527,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/etherael/you-know-nothing-about-cryptocurrencies-366</loc>
@@ -1535,7 +1535,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptocowboy/humanity-and-screens-369</loc>
@@ -1543,7 +1543,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Nohansson/honestwriting-where-is-this-going-370</loc>
@@ -1551,7 +1551,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Nohansson/what-if-371</loc>
@@ -1559,7 +1559,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCom/bitcoin-is-trending-on-google-bitcoin-cash-returns-to-exchanges-and-roger-ver-loves-criminals-373</loc>
@@ -1567,7 +1567,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/bitcoin-cash-374</loc>
@@ -1575,7 +1575,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/sam-shepard-375</loc>
@@ -1583,7 +1583,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JakeMcC/solving-real-world-problems-with-cpu-mining-boid-377</loc>
@@ -1591,7 +1591,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JakeMcC/data-is-a-product-and-you-are-its-owner-lumeos-378</loc>
@@ -1599,7 +1599,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/bitentrepreneur/genesis-post-381</loc>
@@ -1607,7 +1607,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/PumpIronNdCrypto/tor-browser-the-block-chain-prior-to-the-block-chain-384</loc>
@@ -1615,7 +1615,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/us-government-bitcoin-sanctions-are-good-385</loc>
@@ -1623,7 +1623,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Nohansson/i-noticed-so-i-want-to-suggest-386</loc>
@@ -1631,7 +1631,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/my-old-drawing-the-swing-387</loc>
@@ -1639,7 +1639,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/how-to-deal-with-mnemonics-mess-on-honestcash-388</loc>
@@ -1647,7 +1647,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CraigWright/i-am-satoshi-389</loc>
@@ -1655,7 +1655,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/ethereum-in-new-power-390</loc>
@@ -1663,7 +1663,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/PumpIronNdCrypto/has-anyone-actually-went-through-all-of-apples-legal-notices-391</loc>
@@ -1671,7 +1671,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/PumpIronNdCrypto/for-the-record-393</loc>
@@ -1679,7 +1679,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/PumpIronNdCrypto/whos-ready-to-test-this-no-censorship-who-will-be-the-first-banned-do-you-trolls-have-what-it-takes-394</loc>
@@ -1687,7 +1687,7 @@
             2018-12-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/PumpIronNdCrypto/bughunter-hey-honestcash-whats-the-deal-yo-395</loc>
@@ -1695,7 +1695,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Jeovani/where-is-the-bottom-of-the-cryptocurrencies-396</loc>
@@ -1703,7 +1703,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/bitcoin-cash-101-ownership-398</loc>
@@ -1711,7 +1711,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Olsm/introducing-wholesale-by-keys4coins-operate-your-own-automated-online-game-store-with-your-own-design-and-payment-methods-399</loc>
@@ -1719,7 +1719,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adnjoo/bottom-is-attttt-400</loc>
@@ -1727,7 +1727,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/tenqido-dao-401</loc>
@@ -1735,7 +1735,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/could-reactos-help-act-as-an-open-source-windows-alternative-402</loc>
@@ -1743,7 +1743,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/an-old-meme-to-cheer-us-up-405</loc>
@@ -1751,7 +1751,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JakeMcC/stop-paying-google-and-get-paid-to-google-407</loc>
@@ -1759,7 +1759,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/who-is-peter-saddington-408</loc>
@@ -1767,7 +1767,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/is-this-post-uncensorable-too-412</loc>
@@ -1775,7 +1775,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/what-is-the-minimum-i-can-do-413</loc>
@@ -1783,7 +1783,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/title-is-required-414</loc>
@@ -1791,7 +1791,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/how-do-i-unfollow-myself-415</loc>
@@ -1799,7 +1799,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/micro-thoughts-416</loc>
@@ -1807,7 +1807,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/questioning-scientific-faith-the-big-yang-417</loc>
@@ -1815,7 +1815,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cashmodel/mi-presentacion-en-honest-cash-418</loc>
@@ -1823,7 +1823,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/ive-posted-to-telegram-your-post-419</loc>
@@ -1831,7 +1831,7 @@
             2018-12-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/why-im-moving-to-weku-for-now-421</loc>
@@ -1839,7 +1839,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Nohansson/honestwriting-how-are-you-today-423</loc>
@@ -1847,7 +1847,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/2018-young-crypto-entrepreneur-nomination-finalists-424</loc>
@@ -1855,7 +1855,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/core2128/my-little-presentation-before-this-platform-428</loc>
@@ -1863,7 +1863,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/alrashel/the-future-money-429</loc>
@@ -1871,7 +1871,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jscramer/ledger-treasure-puzzle-1-solution-432</loc>
@@ -1879,7 +1879,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/hello-everyone-i-am-royaltiffany-434</loc>
@@ -1887,7 +1887,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/FUBAR165/made-it-into-the-beta-few-things-i-have-noticed-435</loc>
@@ -1895,7 +1895,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AGirl/also-latina-but-not-that-muchof-too-much-436</loc>
@@ -1903,7 +1903,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Twist/the-case-for-social-conservatism-part-2-choose-wisely-437</loc>
@@ -1911,7 +1911,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/bitcoin-cash-haiku-438</loc>
@@ -1919,7 +1919,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/what-are-you-looking-for-440</loc>
@@ -1927,7 +1927,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/blackrain/05122018-betting-tips-441</loc>
@@ -1935,7 +1935,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/the-internet-archive-has-lots-of-old-computer-games-and-software-available-to-play-or-download-442</loc>
@@ -1943,7 +1943,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Zhoujianfu/why-not-have-shorter-block-times-443</loc>
@@ -1951,7 +1951,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCom/bitpay-ceo-on-digital-money-history-and-worldwide-adoption-stephen-pair-interview-444</loc>
@@ -1959,7 +1959,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emergent_reasons/wasteland-4-life-447</loc>
@@ -1967,7 +1967,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_tux/take-that-with-a-grain-of-salt-449</loc>
@@ -1975,7 +1975,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCom/10-days-of-bitmas-at-the-bitcoincom-store-450</loc>
@@ -1983,7 +1983,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ntkweinor/fiat-money-is-the-root-of-all-evil-452</loc>
@@ -1991,7 +1991,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ntkweinor/if-fiat-is-dead-will-bitcoin-replace-it-as-world-currency-a-must-read-453</loc>
@@ -1999,7 +1999,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ntkweinor/vitesio-changing-the-world-of-e-commerce-with-cryptocurrency-456</loc>
@@ -2007,7 +2007,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/all-the-universe-is-mental-mind-457</loc>
@@ -2015,7 +2015,7 @@
             2018-12-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BTCcom/how-to-buy-bitcoin-btc-or-bitcoin-cash-bch-in-the-btccom-wallet-time-to-offer-or-to-get-yourself-an-immutable-crypto-gift-458</loc>
@@ -2023,7 +2023,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/uri/hello-honestcash-world-459</loc>
@@ -2031,7 +2031,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/part-1-of-2-biocentrism-the-case-against-veganism-466</loc>
@@ -2039,7 +2039,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/new-function-change-dont-vote-on-my-post-please-467</loc>
@@ -2047,7 +2047,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/part-2-of-2-vanarcho-biocentrism-the-case-against-the-case-against-veganism-469</loc>
@@ -2055,7 +2055,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/the-modern-future-honoring-primitive-idiots-us-470</loc>
@@ -2063,7 +2063,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/i-cannot-edit-part-1-of-2-biocentrism-the-case-against-veganism-471</loc>
@@ -2071,7 +2071,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/comment-about-sidebar-472</loc>
@@ -2079,7 +2079,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Nohansson/honestwriting-is-this-my-surrender-474</loc>
@@ -2087,7 +2087,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCom/introducing-printable-bitcoin-cash-tips-475</loc>
@@ -2095,7 +2095,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/yes-scarlet-and-here-are-some-resources-476</loc>
@@ -2103,7 +2103,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/memento-mori-can-reflection-on-the-end-of-your-life-help-you-make-better-decisions-in-the-present-477</loc>
@@ -2111,7 +2111,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/blackrain/06-dec-2018-betting-tips-478</loc>
@@ -2119,7 +2119,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nghiacc/crypto-currencies-and-more-generally-blockchains-offer-a-much-more-effective-protection-than-antitrust-law-andor-the-gdpr-combined-479</loc>
@@ -2127,7 +2127,7 @@
             2018-12-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/deadlines-481</loc>
@@ -2135,7 +2135,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ntkweinor/honest-cash-great-read-482</loc>
@@ -2143,7 +2143,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptosignal/btc-ascending-triangle-as-a-reversal-pattern-484</loc>
@@ -2151,7 +2151,7 @@
             2018-12-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/the-intrinsic-value-of-bitcoin-487</loc>
@@ -2159,7 +2159,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/WhaleShark/what-is-the-most-honest-token-design-488</loc>
@@ -2167,7 +2167,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/comment-about-deadlines-489</loc>
@@ -2175,7 +2175,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/a-new-hope-491</loc>
@@ -2183,7 +2183,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/life-can-be-rewarding-if-we-change-our-attitude-492</loc>
@@ -2191,7 +2191,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tom/missing-developer-tooling-493</loc>
@@ -2199,7 +2199,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/theoriginals/blockchain-ftw-the-criminals-elimination-494</loc>
@@ -2207,7 +2207,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/blackrain/06122018-betting-tips-496</loc>
@@ -2215,7 +2215,7 @@
             2018-12-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCash/split-your-coins-bsvbch-498</loc>
@@ -2223,7 +2223,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/attempt-938295739-500</loc>
@@ -2231,7 +2231,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/theoriginals/heres-what-really-matters-in-crypto-currency-ico-502</loc>
@@ -2239,7 +2239,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/build-serverless-apps-with-bitcoin-bitbox-simple-bitcoin-wallet-webpack-503</loc>
@@ -2247,7 +2247,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Shaiq/the-beautiful-indian-occupied-kashmir-504</loc>
@@ -2255,7 +2255,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/did-roger-ver-and-craig-wright-come-to-an-agreement-507</loc>
@@ -2263,7 +2263,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/paid-upvoting-i-dont-like-this-at-all-heres-why-508</loc>
@@ -2271,7 +2271,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Zhoujianfu/more-frequent-blocks-question-511</loc>
@@ -2279,7 +2279,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/folmez/whats-up-yall-513</loc>
@@ -2287,7 +2287,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/we-shouldnt-need-titles-for-comments-514</loc>
@@ -2295,7 +2295,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TheBeardedViking/how-will-honestcash-prevent-social-manipulation-516</loc>
@@ -2303,7 +2303,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/enkidu/bear-market-518</loc>
@@ -2311,7 +2311,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yakyubettor/back-in-day-519</loc>
@@ -2319,7 +2319,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/blackrain/08-dec-2018-betting-tips-521</loc>
@@ -2327,7 +2327,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/WhaleShark/good-read-and-shocked-by-the-results-522</loc>
@@ -2335,7 +2335,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dskloet/response-to-voting-system-523</loc>
@@ -2343,7 +2343,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Moeb/about-forks-selection-mechanisms-and-benfords-law-of-controversy-525</loc>
@@ -2351,7 +2351,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/blackrain/11122018-betting-tips-526</loc>
@@ -2359,7 +2359,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/my-honestcash-wallet-is-still-with-ballance-0-527</loc>
@@ -2367,7 +2367,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lorennys/supera-el-vicio-con-actividad-fisica-528</loc>
@@ -2375,7 +2375,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/matewo/honest-cash-improvements-529</loc>
@@ -2383,7 +2383,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/matewo/blockchain-economy-531</loc>
@@ -2391,7 +2391,7 @@
             2018-12-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/ich-kann-nicht-aufstimmen-532</loc>
@@ -2399,7 +2399,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/maybe-this-534</loc>
@@ -2407,7 +2407,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/honestcash-functionality-535</loc>
@@ -2415,7 +2415,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JakeMcC/will-blockchain-end-the-war-on-drugs-536</loc>
@@ -2423,7 +2423,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/bitcoincom-and-honest-wallets-538</loc>
@@ -2431,7 +2431,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/isnt-that-clickbait-aaa_zioz-539</loc>
@@ -2439,7 +2439,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/why-arent-you-a-programmer-540</loc>
@@ -2447,7 +2447,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/i-connected-my-wallet-again-541</loc>
@@ -2455,7 +2455,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/thought-accountability-bitcoin-remote-viewing-and-the-future-542</loc>
@@ -2463,7 +2463,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/edit-why-do-i-need-to-enter-a-title-if-im-just-commenting-on-another-post-543</loc>
@@ -2471,7 +2471,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AAA_ZioiZ/why-does-it-say-connect-wallet-when-i-try-to-up-vote-545</loc>
@@ -2479,7 +2479,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/macro-micro-thoughts-permissionless-posting-546</loc>
@@ -2487,7 +2487,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Dasterdly/out-of-office-security-547</loc>
@@ -2495,7 +2495,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jsabastine/im-late-to-the-game-but-am-enjoying-it-550</loc>
@@ -2503,7 +2503,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/immutable-editable-mutual-permissionless-551</loc>
@@ -2511,7 +2511,7 @@
             2018-12-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/msncrkl/what-bear-market-29-percent-of-freelancers-would-like-to-be-paid-in-crypto-552</loc>
@@ -2519,7 +2519,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/permissionless-blockchains-and-criminals-what-im-saying-is-shut-down-the-belief-in-government-553</loc>
@@ -2527,7 +2527,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/i-cant-edit-it-and-dont-know-why-554</loc>
@@ -2535,7 +2535,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/oh-so-i-can-connect-the-older-honestcash-seed-556</loc>
@@ -2543,7 +2543,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/favorite-suggested-features-of-danigocrypto-557</loc>
@@ -2551,7 +2551,7 @@
             2018-12-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/wallets-on-honest-cash-558</loc>
@@ -2559,7 +2559,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/this-is-covered-up-on-android-ff-mobile-559</loc>
@@ -2567,7 +2567,7 @@
             2018-12-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/coinbase-considering-30-new-tokens-563</loc>
@@ -2575,7 +2575,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/theoriginals/give-it-a-try-564</loc>
@@ -2583,7 +2583,7 @@
             2018-12-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/two-reasons-to-not-upvote-my-posts-565</loc>
@@ -2591,7 +2591,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/comment-on-two-reasons-566</loc>
@@ -2599,7 +2599,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/MiningDave/never-forget-the-scams-567</loc>
@@ -2607,7 +2607,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/repost-wallets-569</loc>
@@ -2615,7 +2615,7 @@
             2018-12-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/slightly-nsfwtonights-session-starts-now-570</loc>
@@ -2623,7 +2623,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/crypto-this-week-world-wide-report-572</loc>
@@ -2631,7 +2631,7 @@
             2018-12-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SambodhiPrem/root-canal-treatments-573</loc>
@@ -2639,7 +2639,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SambodhiPrem/enjoying-silence-a-meditative-piano-tune-574</loc>
@@ -2647,7 +2647,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/reanarchovegan-575</loc>
@@ -2655,7 +2655,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/anonymous-hacker-statue-drawing-my-reaction-after-2012-acta-fight-576</loc>
@@ -2663,7 +2663,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/IudexOfSimias/choices-responsibility-rights-and-authority-579</loc>
@@ -2671,7 +2671,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/matewo/how-honestcash-will-prevent-social-manipulation-580</loc>
@@ -2679,7 +2679,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AsashoryuMaryBerry/my-accounts-582</loc>
@@ -2687,7 +2687,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/illusion-and-its-impact-on-our-life-584</loc>
@@ -2695,7 +2695,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/old-to-young-beauty-20-second-journey-585</loc>
@@ -2703,7 +2703,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AsashoryuMaryBerry/possible-bug-in-wallet-balance-display-586</loc>
@@ -2711,7 +2711,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lorennys/el-orgullo-y-la-soberbia-587</loc>
@@ -2719,7 +2719,7 @@
             2018-12-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/HODL/hodl-during-this-cryptowinter-591</loc>
@@ -2727,7 +2727,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/HODL/may-i-be-a-writer-592</loc>
@@ -2735,7 +2735,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/is-sunday-a-funday-lets-find-out-593</loc>
@@ -2743,7 +2743,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kain_niaK/bitcoin-cash-the-revolution-595</loc>
@@ -2751,7 +2751,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TreeGuyShaman/tonix-zens-first-newsletter-join-our-health-newsletter-596</loc>
@@ -2759,7 +2759,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/not-a-bug-597</loc>
@@ -2767,7 +2767,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/wekuio-greater-honestcash-greater-yoursorg-598</loc>
@@ -2775,7 +2775,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/is-getting-a-blowjob-from-a-prostitute-wrong-599</loc>
@@ -2783,7 +2783,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/fix-na-i-dont-use-electron-cash-601</loc>
@@ -2791,7 +2791,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/well-thats-new-blank-602</loc>
@@ -2799,7 +2799,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/i-wonder-603</loc>
@@ -2807,7 +2807,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/a-lot-of-potential-a-lot-of-concern-604</loc>
@@ -2815,7 +2815,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/adaptive-algorithm-605</loc>
@@ -2823,7 +2823,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/pictures-and-videos-606</loc>
@@ -2831,7 +2831,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/a-way-to-have-both-editing-and-1-upvote-disable-607</loc>
@@ -2839,7 +2839,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/how-to-achieve-moksha-the-mukti-608</loc>
@@ -2847,7 +2847,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/wouldnt-it-be-nice-to-be-able-to-edit-that-adrian-610</loc>
@@ -2855,7 +2855,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/cryptocurrency-611</loc>
@@ -2863,7 +2863,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/huobi-is-rolling-out-derivative-market-612</loc>
@@ -2871,7 +2871,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/reddit-no-barriers-without-the-blockchain-613</loc>
@@ -2879,7 +2879,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/firstever-bitcoin-real-life-movie-615</loc>
@@ -2887,7 +2887,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/this-is-brilliant-616</loc>
@@ -2895,7 +2895,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptonomoist/bchabcusdt-buy-limit-9556-617</loc>
@@ -2903,7 +2903,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptonomoist/bitcoin-the-economic-phenomenon-618</loc>
@@ -2911,7 +2911,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/deadly-digital-dasies-dancing-part-1-it-begins-619</loc>
@@ -2919,7 +2919,7 @@
             2018-12-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/can-you-follow-me-620</loc>
@@ -2927,7 +2927,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/danke-fur-die-antwort-624</loc>
@@ -2935,7 +2935,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/what-is-meant-by-uncensorable-626</loc>
@@ -2943,7 +2943,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kain_niaK/some-changes-honestcash-should-make-627</loc>
@@ -2951,7 +2951,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/learned-helpfulness-can-you-acquire-the-habit-of-being-proactive-628</loc>
@@ -2959,7 +2959,7 @@
             2018-12-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/comment-about-scams-630</loc>
@@ -2967,7 +2967,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/comment-on-health-631</loc>
@@ -2975,7 +2975,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/self-serve-advertising-on-honestcash-632</loc>
@@ -2983,7 +2983,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/video-embeds-633</loc>
@@ -2991,7 +2991,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/alternatively-634</loc>
@@ -2999,7 +2999,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/what-do-you-think-is-the-best-635</loc>
@@ -3007,7 +3007,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/knowledge-is-power-636</loc>
@@ -3015,7 +3015,7 @@
             2018-12-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/bchbtc-trading-idea-638</loc>
@@ -3023,7 +3023,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/voting-platform-idea-for-bch-640</loc>
@@ -3031,7 +3031,7 @@
             2018-12-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/ads-on-each-blog-642</loc>
@@ -3039,7 +3039,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AsashoryuMaryBerry/1234567890-644</loc>
@@ -3047,7 +3047,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/lets-examine-with-me-why-work-is-worship-645</loc>
@@ -3055,7 +3055,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/social-media-dao-ico-646</loc>
@@ -3063,7 +3063,7 @@
             2018-12-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/futurism-benefits-humanity-647</loc>
@@ -3071,7 +3071,7 @@
             2018-12-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/a-gift-to-give-gratitude-and-rediscovering-what-we-already-have-648</loc>
@@ -3079,7 +3079,7 @@
             2018-12-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/honest-rss-feed-649</loc>
@@ -3087,7 +3087,7 @@
             2018-12-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/please-introduce-this-functionality-only-optionally-650</loc>
@@ -3095,7 +3095,7 @@
             2018-12-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/bitcoin-cash-price-is-currently-consolidating-near-the-dollar100-level-652</loc>
@@ -3103,7 +3103,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Captain/security-tokens-and-utility-tokens-653</loc>
@@ -3111,7 +3111,7 @@
             2018-12-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/bchonest/the-bitcoin-cash-split-network-effect-halving-654</loc>
@@ -3119,7 +3119,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/kiwix-download-all-of-wikipedia-onto-phone-or-computer-656</loc>
@@ -3127,7 +3127,7 @@
             2018-12-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/openbazaar-alternative-657</loc>
@@ -3135,7 +3135,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-story-part-1-continued-658</loc>
@@ -3143,7 +3143,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Olsm/currently-woocommerce-only-659</loc>
@@ -3151,7 +3151,7 @@
             2018-12-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lorennys/do-not-be-a-grinch-661</loc>
@@ -3159,7 +3159,7 @@
             2018-12-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/are-negative-and-positive-emotions-contagious-663</loc>
@@ -3167,7 +3167,7 @@
             2018-12-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/j8keb/sega-hockey-94-test-664</loc>
@@ -3175,7 +3175,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptonomoist/bitcoin-price-has-bottomed-665</loc>
@@ -3183,7 +3183,7 @@
             2018-12-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/we-can-potentially-defeat-aging-666</loc>
@@ -3191,7 +3191,7 @@
             2018-12-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chicken/mediumcom-is-engaging-in-ongoing-stealth-censorship-why-all-crypto-discussion-should-migrate-off-of-mediumcom-670</loc>
@@ -3199,7 +3199,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/can-an-alternative-keyboard-layout-like-colemak-improve-your-typing-speed-and-comfort-671</loc>
@@ -3207,7 +3207,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/flaws-in-proof-of-work-consensus-673</loc>
@@ -3215,7 +3215,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/cryptocurrency-market-is-bleeding-and-really-bleeding-to-the-core-674</loc>
@@ -3223,7 +3223,7 @@
             2018-12-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/crypto-market-fundamental-and-technical-analysis-15122018-675</loc>
@@ -3231,7 +3231,7 @@
             2018-12-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lorennys/double-portion-676</loc>
@@ -3239,7 +3239,7 @@
             2018-12-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/macks/hey-great-to-see-you-here-677</loc>
@@ -3247,7 +3247,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JakeMcC/are-we-building-the-simulation-or-was-it-built-679</loc>
@@ -3255,7 +3255,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/creating-and-establishing-decentralized-autonomous-or-organizations-681</loc>
@@ -3263,7 +3263,7 @@
             2018-12-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/theoriginals/how-to-get-a-vote-683</loc>
@@ -3271,7 +3271,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JZA/crypto-user-group-in-cancun-685</loc>
@@ -3279,7 +3279,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/welcome-kyle-686</loc>
@@ -3287,7 +3287,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/new-chillandcrowdfund-channel-new-video-688</loc>
@@ -3295,7 +3295,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/phabulu/honestcash-is-an-alternative-to-yoursorg-yoursorg-scam-690</loc>
@@ -3303,7 +3303,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/crypto-market-fundamental-and-technical-analysis-1712-691</loc>
@@ -3311,7 +3311,7 @@
             2018-12-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chicken/p3cio-project-update-122818-data-data-and-our-new-merchant-portal-692</loc>
@@ -3319,7 +3319,7 @@
             2018-12-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/china-planea-dejar-de-lado-bitcoin-696</loc>
@@ -3327,7 +3327,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/atlas-shrugged-by-ayn-rand-697</loc>
@@ -3335,7 +3335,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Miningbiz/antminer-s9-switched-off-hash-rate-drop-13-mln-699</loc>
@@ -3343,7 +3343,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/whos-up-for-a-fun-night-704</loc>
@@ -3351,7 +3351,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/monday-meme-705</loc>
@@ -3359,7 +3359,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/techkajadi/santa-claus-is-coming-with-a-lot-of-surprises-for-the-cryptocurrency-market-707</loc>
@@ -3367,7 +3367,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/forced-re-login-709</loc>
@@ -3375,7 +3375,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/planning-increases-joy-710</loc>
@@ -3383,7 +3383,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/nice-little-sounds-711</loc>
@@ -3391,7 +3391,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/late-is-relative-712</loc>
@@ -3399,7 +3399,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/trusted-proof-of-stake-investment-vehicle-714</loc>
@@ -3407,7 +3407,7 @@
             2018-12-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/bitcoin-cash-sv-bchsv-skyrockets-875-as-the-hash-war-comes-to-a-close-715</loc>
@@ -3415,7 +3415,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darwin/can-we-cut-the-crap-please-bitman007-716</loc>
@@ -3423,7 +3423,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/album-review-earl-sweatshirt-some-rap-songs-720</loc>
@@ -3431,7 +3431,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/introduction-cryptoshoppe-721</loc>
@@ -3439,7 +3439,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/im-new-anybody-help-722</loc>
@@ -3447,7 +3447,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/what-people-thought-about-bitcoin-years-ago-the-coin-that-never-launched-723</loc>
@@ -3455,7 +3455,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/bonfire-collective-a-meditation-on-motivation-vs-procrastination-724</loc>
@@ -3463,7 +3463,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/bitcoin-cash-bch-debunking-the-fud-725</loc>
@@ -3471,7 +3471,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/1kbken/the-middle-road-727</loc>
@@ -3479,7 +3479,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/phabulu/fast-and-easy-use-your-coinomi-wallet-to-clain-your-bitcoin-sv-bsv-731</loc>
@@ -3487,7 +3487,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/its-honestcash-733</loc>
@@ -3495,7 +3495,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-btc-734</loc>
@@ -3503,7 +3503,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/openbazaar-freedom-simplified-737</loc>
@@ -3511,7 +3511,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/amgedraees/tron-trx-738</loc>
@@ -3519,7 +3519,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/op-ed-the-master-coins-journey-for-sound-money-742</loc>
@@ -3527,7 +3527,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/response-to-can-an-alternative-keyboard-layout-like-colemak-improve-your-typing-speed-and-comfort-by-ridedonkeys-743</loc>
@@ -3535,7 +3535,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/making-the-honestcash-initiative-better-744</loc>
@@ -3543,7 +3543,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emrosedallara/will-crypto-choose-you-748</loc>
@@ -3551,7 +3551,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/op-ed-spotting-crypto-wolves-in-sheeps-clothing-749</loc>
@@ -3559,7 +3559,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitman007/it-looks-like-bitcoin-has-found-a-new-bottom-750</loc>
@@ -3567,7 +3567,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Paisleylove/happy-to-be-a-part-of-the-honestcash-community-752</loc>
@@ -3575,7 +3575,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Paisleylove/welcome-gave-you-a-follow-753</loc>
@@ -3583,7 +3583,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/welcome-darkson-754</loc>
@@ -3591,7 +3591,7 @@
             2018-12-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/hey-there-760</loc>
@@ -3599,7 +3599,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/missed-me-761</loc>
@@ -3607,7 +3607,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/can-bitcoin-survive-a-difficulty-crash-764</loc>
@@ -3615,7 +3615,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/the-art-of-the-mash-up-aka-vicarious-expressionism-766</loc>
@@ -3623,7 +3623,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/tezos-xtz-is-now-on-huobi-global-soma-should-be-next-767</loc>
@@ -3631,7 +3631,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/how-do-you-attach-photographs-770</loc>
@@ -3639,7 +3639,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/me-amidst-really-good-friends-771</loc>
@@ -3647,7 +3647,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/why-bass-guitarists-are-underrated-772</loc>
@@ -3655,7 +3655,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-eth-773</loc>
@@ -3663,7 +3663,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/why-solid-state-drives-ssds-are-the-future-774</loc>
@@ -3671,7 +3671,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/i-dont-think-so-775</loc>
@@ -3679,7 +3679,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Nurain/introduction-content-expected-777</loc>
@@ -3687,7 +3687,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Geri/reply-reply-778</loc>
@@ -3695,7 +3695,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darwin/this-is-an-obvious-scam-779</loc>
@@ -3703,7 +3703,7 @@
             2018-12-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/re-old-and-newer-ssds-782</loc>
@@ -3711,7 +3711,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/hey-there-783</loc>
@@ -3719,7 +3719,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/well-i-am-back-for-another-session-784</loc>
@@ -3727,7 +3727,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Minehashrate/do-you-thing-bitcoin-price-in-new-year-2019-785</loc>
@@ -3735,7 +3735,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/hey-there-786</loc>
@@ -3743,7 +3743,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/capture-a-short-story-787</loc>
@@ -3751,7 +3751,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoIndia/buy-bitcoin-789</loc>
@@ -3759,7 +3759,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/why-i-am-invested-in-bitcoin-cash-790</loc>
@@ -3767,7 +3767,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emrosedallara/keep-attracting-the-good-stuff-791</loc>
@@ -3775,7 +3775,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TheMule/its-time-to-start-viewing-bch-as-part-of-an-ecosystem-793</loc>
@@ -3783,7 +3783,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-six-year-old-794</loc>
@@ -3791,7 +3791,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/observing-the-honestcash-site-795</loc>
@@ -3799,7 +3799,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoIndia/buy-tnt-in-binance-798</loc>
@@ -3807,7 +3807,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCashNB/the-cyphernomicon-799</loc>
@@ -3815,7 +3815,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCashNB/the-cyphernomicon-cont-801</loc>
@@ -3823,7 +3823,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCashNB/the-cyphernomicon-cont-802</loc>
@@ -3831,7 +3831,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCashNB/the-cyphernomicon-cont-803</loc>
@@ -3839,7 +3839,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCashNB/the-cyphernomicon-cont-805</loc>
@@ -3847,7 +3847,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/IudexOfSimias/the-fine-line-of-conversation-806</loc>
@@ -3855,7 +3855,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Minehashrate/play-dice-bitcoins-807</loc>
@@ -3863,7 +3863,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/122017-latest-projections-show-btc-will-break-the-time-space-continuum-808</loc>
@@ -3871,7 +3871,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/was-my-heart-broken-809</loc>
@@ -3879,7 +3879,7 @@
             2018-12-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/more-observations-on-the-honestcash-site-812</loc>
@@ -3887,7 +3887,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/yeah-this-update-happened-because-of-you-815</loc>
@@ -3895,7 +3895,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/RoyalTiffany/last-night-live-until-after-xmas-enjoy-the-previews-d-happy-holidays-hc-816</loc>
@@ -3903,7 +3903,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TreeGuyShaman/tonic-zen-health-and-spiritual-wellness-817</loc>
@@ -3911,7 +3911,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/establishing-public-key-818</loc>
@@ -3919,7 +3919,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/agreedand-the-title-is-too-short-so-im-adding-this-819</loc>
@@ -3927,7 +3927,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/thank-you-honest-team-820</loc>
@@ -3935,7 +3935,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/lol-your-title-tho-821</loc>
@@ -3943,7 +3943,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/gameloft-v-the-world-part-1-822</loc>
@@ -3951,7 +3951,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/alrashel/bitcoin-is-going-up-as-expected-824</loc>
@@ -3959,7 +3959,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Coolzero/feral-cats-in-my-town-825</loc>
@@ -3967,7 +3967,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TheOneLaw/bip-39-wallet-derivation-problem-828</loc>
@@ -3975,7 +3975,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoIndia/quarkchain-bounty-program-829</loc>
@@ -3983,7 +3983,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-ltc-830</loc>
@@ -3991,7 +3991,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/stormy-coastal-landscape-thunder-cloud-and-rain-831</loc>
@@ -3999,7 +3999,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TheOneLaw/wallet-works-832</loc>
@@ -4007,7 +4007,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/the-sanctity-of-pow-833</loc>
@@ -4015,7 +4015,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Minehashrate/duckdice-bitcoin-dice-game-834</loc>
@@ -4023,7 +4023,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/guia-sencilla-de-bitcoin-lightening-pierre-rochard-series-article-1-837</loc>
@@ -4031,7 +4031,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/the-point-isnt-quality-content-but-to-use-it-840</loc>
@@ -4039,7 +4039,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/oh-thats-what-that-number-means-841</loc>
@@ -4047,7 +4047,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/lol-wtf-is-up-with-the-wallet-system-842</loc>
@@ -4055,7 +4055,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/tips-go-to-the-address-specified-in-your-profile-843</loc>
@@ -4063,7 +4063,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/why-i-now-agree-with-ryan-on-sv-844</loc>
@@ -4071,7 +4071,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/cccant-see-this-845</loc>
@@ -4079,7 +4079,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/calisi/is-censorship-really-bad-848</loc>
@@ -4087,7 +4087,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TreeGuyShaman/fundraiser-tonic-zen-health-and-spiritual-wellness-849</loc>
@@ -4095,7 +4095,7 @@
             2018-12-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/avalanche-into-bch-pow-851</loc>
@@ -4103,7 +4103,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/FUBAR165/idea-for-a-decentralized-youtube-replacement-852</loc>
@@ -4111,7 +4111,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/avoid-arguments-for-a-healthier-relationship-853</loc>
@@ -4119,7 +4119,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nghiacc/great-idea-usability-is-first-855</loc>
@@ -4127,7 +4127,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/even-more-observations-on-the-honestcash-site-856</loc>
@@ -4135,7 +4135,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/____________-857</loc>
@@ -4143,7 +4143,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/-858</loc>
@@ -4151,7 +4151,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/is-a-blockchain-needed-859</loc>
@@ -4159,7 +4159,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/perhaps-it-could-be-hidden-860</loc>
@@ -4167,7 +4167,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/the-point-is-use-not-quality-861</loc>
@@ -4175,7 +4175,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/reminds-me-of-some-nights-862</loc>
@@ -4183,7 +4183,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/try-lbryio-863</loc>
@@ -4191,7 +4191,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/___________-865</loc>
@@ -4199,7 +4199,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypo-characters-bch-867</loc>
@@ -4207,7 +4207,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/__________-868</loc>
@@ -4215,7 +4215,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/quality-over-quantity-high-aspirations-869</loc>
@@ -4223,7 +4223,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/forcing-quality-870</loc>
@@ -4231,7 +4231,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/i-first-heard-this-phrase-in-a-song-by-the-streets-871</loc>
@@ -4239,7 +4239,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/heres-how-to-use-memocash-with-honestcash-872</loc>
@@ -4247,7 +4247,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/tomorrow-december-30th-874</loc>
@@ -4255,7 +4255,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/why-bass-guitarists-are-appreciated-875</loc>
@@ -4263,7 +4263,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/no-ryan-law-is-like-btc-876</loc>
@@ -4271,7 +4271,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/benefits-of-upvoting-great-content-early-878</loc>
@@ -4279,7 +4279,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/benefits-of-upvoting-great-content-early-879</loc>
@@ -4287,7 +4287,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/1-upvote-editing-disabled-criticism-and-critique-is-appreciation-880</loc>
@@ -4295,7 +4295,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/i-agree-with-your-assertion-881</loc>
@@ -4303,7 +4303,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/some-more-observations-on-the-honestcash-site-882</loc>
@@ -4311,7 +4311,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/im-glad-you-agree-criticism-is-not-discrediting-883</loc>
@@ -4319,7 +4319,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/you-have-a-lot-of-points-884</loc>
@@ -4327,7 +4327,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/thank-you-darkson-885</loc>
@@ -4335,7 +4335,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/other-users-including-myself-agree-darkson-886</loc>
@@ -4343,7 +4343,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/______________-887</loc>
@@ -4351,7 +4351,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/response-expansive-conservation-of-energy-888</loc>
@@ -4359,7 +4359,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/better-one-889</loc>
@@ -4367,7 +4367,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/us-tells-israel-we-are-not-done-with-syria-secret-anti-bds-law-in-spending-bill-and-mattis-quits-891</loc>
@@ -4375,7 +4375,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/us-syria-war-not-ending-isis-attacks-yemen-still-being-bombed-by-us-and-normalization-of-endless-war-892</loc>
@@ -4383,7 +4383,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/what-is-your-prediction-of-btc-price-on-31st-dec-2018-895</loc>
@@ -4391,7 +4391,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/can-you-follow-me-so-that-i-can-follow-you-back-896</loc>
@@ -4399,7 +4399,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/request-to-follow-back-897</loc>
@@ -4407,7 +4407,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/thanks-for-the-feedback-898</loc>
@@ -4415,7 +4415,7 @@
             2018-12-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/whats-coming-for-honest-in-the-next-days-recommendations-899</loc>
@@ -4423,7 +4423,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/story-time-i-called-this-capture-900</loc>
@@ -4431,7 +4431,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SambodhiPrem/sampling-piano-is-fun-904</loc>
@@ -4439,7 +4439,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoSignals/a-basic-guide-on-how-to-evaluate-blockchain-assets-906</loc>
@@ -4447,7 +4447,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yasu/post-907</loc>
@@ -4455,7 +4455,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-xrp-908</loc>
@@ -4463,7 +4463,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/childhood-my-original-poem-909</loc>
@@ -4471,7 +4471,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-xlm-910</loc>
@@ -4479,7 +4479,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Phantom/honestcash-work-in-progress-911</loc>
@@ -4487,7 +4487,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/unlisted-youtube-about-keyport-on-memo-912</loc>
@@ -4495,7 +4495,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/bitsmart4/wish2binance-dollar10000-913</loc>
@@ -4503,7 +4503,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/cryptoshoppes-upcoming-stories-914</loc>
@@ -4511,7 +4511,7 @@
             2018-12-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/gameloft-v-the-world-part-2-916</loc>
@@ -4519,7 +4519,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/op-ed-what-is-stonewalling-the-quest-for-sound-money-917</loc>
@@ -4527,7 +4527,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/vlog-i-want-to-use-bsv-at-places-like-amazon-cub-whole-foods-and-subway-918</loc>
@@ -4535,7 +4535,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/what-will-hyperbitcoinization-look-like-920</loc>
@@ -4543,7 +4543,7 @@
             2018-12-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-eos-921</loc>
@@ -4551,7 +4551,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/picture-test-922</loc>
@@ -4559,7 +4559,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/op-ed-why-an-artificial-intelligence-system-could-have-made-bitcoin-923</loc>
@@ -4567,7 +4567,7 @@
             2018-12-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Minehashrate/chinese-miner-dealers-star-the-dumping-war-924</loc>
@@ -4575,7 +4575,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Minehashrate/5-tips-for-bitcoin-miners-in-bears-925</loc>
@@ -4583,7 +4583,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/why-is-there-a-pedophilic-undertone-to-the-gay-agenda-926</loc>
@@ -4591,7 +4591,7 @@
             2018-12-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Nurain/how-to-become-a-better-software-developer-929</loc>
@@ -4599,7 +4599,7 @@
             2018-12-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/my-weku-is-down-930</loc>
@@ -4607,7 +4607,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/happy-holidays-931</loc>
@@ -4615,7 +4615,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/phabulu/pandora-101-932</loc>
@@ -4623,7 +4623,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Minehashrate/please-read-my-post-933</loc>
@@ -4631,7 +4631,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Minehashrate/blockchain-lotto-a-new-alternative-that-everyone-overlooked-934</loc>
@@ -4639,7 +4639,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-monero-xmr-936</loc>
@@ -4647,7 +4647,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-nem-937</loc>
@@ -4655,7 +4655,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/richze90/what-are-cryptocurrencies-939</loc>
@@ -4663,7 +4663,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/guia-rapida-para-lightening-con-iniciador-de-nodo-zap-pierre-rochard-series-article-2-940</loc>
@@ -4671,7 +4671,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/envia-un-pago-relampago-usando-zap-para-escritorio-pierre-rochard-series-article-3-941</loc>
@@ -4679,7 +4679,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/bitcoin-lightening-extension-para-joule-chrome-pierre-rochard-series-article-4-942</loc>
@@ -4687,7 +4687,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/quality-of-life-943</loc>
@@ -4695,7 +4695,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/welcome-to-honest-944</loc>
@@ -4703,7 +4703,7 @@
             2018-12-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/PavelAlechin/get-paid-for-services-or-products-becomes-profitable-947</loc>
@@ -4711,7 +4711,7 @@
             2018-12-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/avalanche-in-three-questions-948</loc>
@@ -4719,7 +4719,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/quickie-review-bird-box-and-black-mirrors-bandersnatch-950</loc>
@@ -4727,7 +4727,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-dash-951</loc>
@@ -4735,7 +4735,7 @@
             2018-12-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/good-questions-but-avoid-fud-955</loc>
@@ -4743,7 +4743,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-alts-959</loc>
@@ -4751,7 +4751,7 @@
             2018-12-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-tether-960</loc>
@@ -4759,7 +4759,7 @@
             2018-12-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/how-to-build-the-near-perfect-personality-1-961</loc>
@@ -4767,7 +4767,7 @@
             2018-12-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/crypto-gems-you-should-keep-a-watch-on-2019-962</loc>
@@ -4775,7 +4775,7 @@
             2018-12-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/como-escapar-de-la-volatilidad-en-binance-a-traves-de-las-stablecoins-964</loc>
@@ -4783,7 +4783,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/bitcoin-puede-alcanzar-los-dollar-333000-para-2023-965</loc>
@@ -4791,7 +4791,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/polychromic-grimes-967</loc>
@@ -4799,7 +4799,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/michaelten/call-your-senator-and-tell-them-to-defeat-aging-968</loc>
@@ -4807,7 +4807,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/how-to-get-a-vote-969</loc>
@@ -4815,7 +4815,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/can-cloud-mining-make-you-rich-970</loc>
@@ -4823,7 +4823,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/re-good-questions-but-avoid-fud-973</loc>
@@ -4831,7 +4831,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/wine-company-buys-crypto-exchange-974</loc>
@@ -4839,7 +4839,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-cardano-976</loc>
@@ -4847,7 +4847,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/redpepper/bch-giveaway-on-twitch-979</loc>
@@ -4855,7 +4855,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/DerekCano/please-help-me-save-my-sons-life-for-years-suffer-from-brain-cancer-982</loc>
@@ -4863,7 +4863,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/trump-names-fmr-boeing-exec-secdef-israel-vows-more-syria-attacks-and-white-helmets-organ-harvesting-983</loc>
@@ -4871,7 +4871,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/floating-gitmo-nyt-prints-hacked-cables-while-assange-is-being-persecuted-and-normalizing-pedophilia-984</loc>
@@ -4879,7 +4879,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-attacks-syria-on-xmas-netanyahu-dissolves-israeli-parliament-and-us-coalition-bombs-deir-ezzor-985</loc>
@@ -4887,7 +4887,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-admits-attacking-syria-us-coordinates-syria-occupation-with-turkey-and-us-gives-ukraine-dollar250m-986</loc>
@@ -4895,7 +4895,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/us-commanders-dismiss-afghan-drawdown-rumors-manbij-psyop-and-saudis-violate-hodeida-ceasefire-400x-987</loc>
@@ -4903,7 +4903,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/how-to-build-the-near-perfect-personality-2-988</loc>
@@ -4911,7 +4911,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SeanBallard/why-are-you-in-bitcoin-989</loc>
@@ -4919,7 +4919,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-was-either-meditation-or-prison-990</loc>
@@ -4927,7 +4927,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Geri/akkos-last-magic-991</loc>
@@ -4935,7 +4935,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/redpepper/setup-seven-new-people-with-wallets-992</loc>
@@ -4943,7 +4943,7 @@
             2018-12-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/and-if-i-dont-use-electron-994</loc>
@@ -4951,7 +4951,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/DerekCano/please-help-me-save-my-sons-life-from-8-years-old-suffer-brain-cancer-996</loc>
@@ -4959,7 +4959,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/interesting-piece-997</loc>
@@ -4967,7 +4967,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Money78/your-prayers-just-got-answered-998</loc>
@@ -4975,7 +4975,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/never-hurt-someones-heart-relations-are-a-valuable-gift-of-almighty-god-1001</loc>
@@ -4983,7 +4983,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-tron-1002</loc>
@@ -4991,7 +4991,7 @@
             2018-12-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/video-games-and-programming-development-1003</loc>
@@ -4999,7 +4999,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Falopeolakunle/why-the-germans-lost-the-2nd-world-war-basically-1004</loc>
@@ -5007,7 +5007,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Falopeolakunle/quick-story-of-bitcoin-1005</loc>
@@ -5015,7 +5015,7 @@
             2018-12-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Falopeolakunle/why-racism-is-very-bad-and-how-it-affects-different-people-both-white-n-black-1006</loc>
@@ -5023,7 +5023,7 @@
             2018-12-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Vagabond/what-to-expect-in-crypto-2019-1008</loc>
@@ -5031,7 +5031,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/MobTwo/this-is-why-i-am-supporting-bitcoin-cash-1010</loc>
@@ -5039,7 +5039,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chicken/how-to-save-p3c-dapp-tokens-in-cold-storage-with-a-paper-or-hardware-wallet-1011</loc>
@@ -5047,7 +5047,7 @@
             2018-12-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-1012</loc>
@@ -5055,7 +5055,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/top-10-mining-pools-of-2018-1014</loc>
@@ -5063,7 +5063,7 @@
             2018-12-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SeanBallard/cant-spell-culture-witho-the-cult-1015</loc>
@@ -5071,7 +5071,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/rahuldhyani/triple-divorce-bill-law-in-india-1016</loc>
@@ -5079,7 +5079,7 @@
             2018-12-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Falopeolakunle/manchester-united-is-becoming-better-since-the-departure-of-jose-mourinho-1017</loc>
@@ -5087,7 +5087,7 @@
             2018-12-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/rahuldhyani/racism-is-bad-at-all-level-1018</loc>
@@ -5095,7 +5095,7 @@
             2018-12-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/cyberpunk-art-crypto-hack-1021</loc>
@@ -5103,7 +5103,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-story-chapter-2-1023</loc>
@@ -5111,7 +5111,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Falopeolakunle/happy-new-year-everybody-1024</loc>
@@ -5119,7 +5119,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-the-tease-1025</loc>
@@ -5127,7 +5127,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-the-introduction-1026</loc>
@@ -5135,7 +5135,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-the-cast-of-characters-1027</loc>
@@ -5143,7 +5143,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-introduction-contd-1028</loc>
@@ -5151,7 +5151,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-1-it-begins-1029</loc>
@@ -5159,7 +5159,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-2-dinner-for-just-the-two-of-us-1030</loc>
@@ -5167,7 +5167,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-3-drinks-and-more-on-the-patio-1031</loc>
@@ -5175,7 +5175,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-4-in-her-bed-1032</loc>
@@ -5183,7 +5183,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-5-oh-what-a-morning-1033</loc>
@@ -5191,7 +5191,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-6-the-ladies-do-lunch-1034</loc>
@@ -5199,7 +5199,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-7-archer-arrives-from-india-1035</loc>
@@ -5207,7 +5207,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-8-meditating-with-kundalini-1036</loc>
@@ -5215,7 +5215,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-9-what-do-you-do-if-you-dont-have-sex-1037</loc>
@@ -5223,7 +5223,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-10-tales-from-the-orient-1038</loc>
@@ -5231,7 +5231,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-11-the-chicago-wayback-in-the-day-1039</loc>
@@ -5239,7 +5239,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-12-surprise-1040</loc>
@@ -5247,7 +5247,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-13-finally-a-full-menu-1041</loc>
@@ -5255,7 +5255,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-14-baby-needs-some-love-1042</loc>
@@ -5263,7 +5263,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-15-that-was-rough-1043</loc>
@@ -5271,7 +5271,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-16-the-scene-at-the-pool-1044</loc>
@@ -5279,7 +5279,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-17-what-a-rude-awakening-1045</loc>
@@ -5287,7 +5287,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-chapter-18-the-cliffhanger-1046</loc>
@@ -5295,7 +5295,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/it-all-started-with-a-suitcase-full-of-cash-iaswasfoc-epilogue-1047</loc>
@@ -5303,7 +5303,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/join-the-proof-of-keys-movement-1048</loc>
@@ -5311,7 +5311,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-iota-1050</loc>
@@ -5319,7 +5319,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/hybrid-p2p-networks-1051</loc>
@@ -5327,7 +5327,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/sken/first-post-1052</loc>
@@ -5335,7 +5335,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/redpepper/next-bch-chicken-giveaway-1053</loc>
@@ -5343,7 +5343,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/the-mars-blockchain-project-issues-stablecoin-on-kryptono-1054</loc>
@@ -5351,7 +5351,7 @@
             2019-01-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/the-raiden-network-and-some-specifications-1055</loc>
@@ -5359,7 +5359,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/thanks-for-the-reviews-1057</loc>
@@ -5367,7 +5367,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/mysterious-death-of-bre-payton-israels-mask-removed-reconsidering-syria-withdrawal-and-2019-shift-1058</loc>
@@ -5375,7 +5375,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoShoppe/your-weku-page-1059</loc>
@@ -5383,7 +5383,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Maximus/tres-dur-la-vie-1060</loc>
@@ -5391,7 +5391,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-zcash-1061</loc>
@@ -5399,7 +5399,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/new-years-resolutions-1062</loc>
@@ -5407,7 +5407,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/emoji-support-1063</loc>
@@ -5415,7 +5415,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/oscillatewildly-you-shouldnt-let-poets-lie-to-you-bjork-explaining-how-tvs-work-1064</loc>
@@ -5423,7 +5423,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TrySomeNashville/hello-world-1065</loc>
@@ -5431,7 +5431,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darwin/support-creatives-1069</loc>
@@ -5439,7 +5439,7 @@
             2019-01-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/happy-new-year-1071</loc>
@@ -5447,7 +5447,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/what-the-hll-is-the-difference-between-stock-and-broth-1072</loc>
@@ -5455,7 +5455,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/happy-new-year-to-you-too-1073</loc>
@@ -5463,7 +5463,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/mimblewimble-launches-beam-vs-grin-1075</loc>
@@ -5471,7 +5471,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/awesome-glad-you-enjoyed-the-reviews-1076</loc>
@@ -5479,7 +5479,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-binance-coin-1077</loc>
@@ -5487,7 +5487,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/DaSpawn/and-so-it-begins-1078</loc>
@@ -5495,7 +5495,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/market-sentiment-and-my-gratitude-for-blockchain-1081</loc>
@@ -5503,7 +5503,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/i-did-too-short-huh-1083</loc>
@@ -5511,7 +5511,7 @@
             2019-01-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/us-coalitions-work-with-extremists-wfp-withholds-yemen-food-syria-contradictions-and-anti-bds-agenda-1084</loc>
@@ -5519,7 +5519,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/_______done-1086</loc>
@@ -5527,7 +5527,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Dasterdly/where-does-malware-strike-most-1087</loc>
@@ -5535,7 +5535,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/overstock-pays-the-companys-business-tax-in-bitcoin-1088</loc>
@@ -5543,7 +5543,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/an-idea-for-bitcoin-cash-1089</loc>
@@ -5551,7 +5551,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-favorite-japanese-movies-1090</loc>
@@ -5559,7 +5559,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lechango/re-an-idea-for-bitcoin-cash-1091</loc>
@@ -5567,7 +5567,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tushar435/bitcoin-cash-is-a-real-bitcoin-1093</loc>
@@ -5575,7 +5575,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tushar435/daap-on-bch-1094</loc>
@@ -5583,7 +5583,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tushar435/my-stories-entering-in-to-crypto-1095</loc>
@@ -5591,7 +5591,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lol_bcash/lol-bcash-lol-bcash-lol-bcash-1097</loc>
@@ -5599,7 +5599,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/50-minutes-to-motivation-1098</loc>
@@ -5607,7 +5607,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/matewo/re-an-idea-for-honest-ratings-1099</loc>
@@ -5615,7 +5615,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Dasterdly/the-million-dollar-dissident-1100</loc>
@@ -5623,7 +5623,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Dasterdly/bitter-sweet-part-2-of-9-1101</loc>
@@ -5631,7 +5631,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Dasterdly/edward-snowden-discussing-nso-group-malware-privacy-issues-1102</loc>
@@ -5639,7 +5639,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/exactly-my-point-1106</loc>
@@ -5647,7 +5647,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/just-one-more-leap-of-faith-1107</loc>
@@ -5655,7 +5655,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/the-most-sought-out-stablecoins-in-the-cryptocurrency-market-1108</loc>
@@ -5663,7 +5663,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/pnac-wars-analysts-confirm-israel-used-civilians-to-mask-attack-and-2020-political-theater-begins-1109</loc>
@@ -5671,7 +5671,7 @@
             2019-01-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/3-easy-steps-to-earn-some-bitcoin-cash-1110</loc>
@@ -5679,7 +5679,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/lets-live-a-ubuntu-life-1111</loc>
@@ -5687,7 +5687,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-bitcoin-gold-1112</loc>
@@ -5695,7 +5695,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/cashport-a-new-software-developer-kit-for-bitcoin-cash-1113</loc>
@@ -5703,7 +5703,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/cyberpunk-gal-1115</loc>
@@ -5711,7 +5711,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/thanks-for-letting-us-know-1116</loc>
@@ -5719,7 +5719,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/geluero1/meetups-bch-valencia-venezuela-we-need-help-1118</loc>
@@ -5727,7 +5727,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lorennys/new-years-2019-1120</loc>
@@ -5735,7 +5735,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/love-it_________-1122</loc>
@@ -5743,7 +5743,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Dasterdly/shitcoin-get-a-lesson-from-daniel-krawisz-1123</loc>
@@ -5751,7 +5751,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/pay-2-read-and-censor-vs-spam-1124</loc>
@@ -5759,7 +5759,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/how-about-getting-rid-of-title-requirements-for-comments-1125</loc>
@@ -5767,7 +5767,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/title-is-not-needed-1127</loc>
@@ -5775,7 +5775,7 @@
             2019-01-05
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/insufficient-balance-1128</loc>
@@ -5783,7 +5783,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/peak_fud/the-long-game-of-the-btc-is-now-evident-in-the-market-an-autopsy-1131</loc>
@@ -5791,7 +5791,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/OrangeJuice/keep-up-the-good-work-1135</loc>
@@ -5799,7 +5799,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Aterragon/the-dark-overlord-1136</loc>
@@ -5807,7 +5807,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/value-polls-vs-opinion-polls-1137</loc>
@@ -5815,7 +5815,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/us-may-stay-in-syria-despite-trump-decree-bolton-hints-at-syria-false-flag-and-dc-murder-jumps-40-1139</loc>
@@ -5823,7 +5823,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/is-information-dangerous-1140</loc>
@@ -5831,7 +5831,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/the-greatest-movie-ever-1141</loc>
@@ -5839,7 +5839,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/ummm-text-in-parenthesis-is-filler-because-my-title-is-too-short-1142</loc>
@@ -5847,7 +5847,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/i-have-no-title-for-this-reply-1143</loc>
@@ -5855,7 +5855,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/this-is-the-required-title-field-1144</loc>
@@ -5863,7 +5863,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Logan/nice-tutorial-1145</loc>
@@ -5871,7 +5871,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/calisi/i-totally-agree-with-you-but-also-1147</loc>
@@ -5879,7 +5879,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nicewoody69/the-queen-and-the-kingslayer-1149</loc>
@@ -5887,7 +5887,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/discussion-on-reddit-1152</loc>
@@ -5895,7 +5895,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/binance-seeks-to-satisfy-us-interests-1154</loc>
@@ -5903,7 +5903,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/us-authorities-issue-majority-of-subpoenas-to-kraken-1155</loc>
@@ -5911,7 +5911,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/a-list-of-cryptocurrency-accounting-firms-1160</loc>
@@ -5919,7 +5919,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/chungking-express-1164</loc>
@@ -5927,7 +5927,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/great-choice-1166</loc>
@@ -5935,7 +5935,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/so-whats-your-nomination-1167</loc>
@@ -5943,7 +5943,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SpendBCH/bitcoin-cash-ecosystem-growth-load-a-bitcoinfilescom-smart-contract-directly-from-the-bch-chain-to-cashytools-with-checkdatasig-oracle-data-then-fund-with-badger-wallet-to-broadcast-to-bitcoincoms-public-bitbox-rest-cloud-1168</loc>
@@ -5951,7 +5951,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/well-funded-meddlers-1170</loc>
@@ -5959,7 +5959,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darwin/minor-stuff-no-date-on-original-article-yet-date-on-replies-says-jan-5-19-1171</loc>
@@ -5967,7 +5967,7 @@
             2019-01-06
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AD1AD/reduction-of-influence-is-not-arbitrary-and-is-user-specific-1172</loc>
@@ -5975,7 +5975,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/greatest-movie-ever-1174</loc>
@@ -5983,7 +5983,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/these-are-a-few-of-my-least-favorite-things-1175</loc>
@@ -5991,7 +5991,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/first-2019-senate-bill-is-anti-bds-us-syria-airstrikes-increase-and-bolton-says-us-not-leaving-syria-1176</loc>
@@ -5999,7 +5999,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/sorting-replies-by-value-1177</loc>
@@ -6007,7 +6007,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/minister-urges-construction-companies-to-accept-petro-1178</loc>
@@ -6015,7 +6015,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/the-law-behind-how-bitcoin-price-rise-1179</loc>
@@ -6023,7 +6023,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-ethereum-classic-1181</loc>
@@ -6031,7 +6031,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-etc-vs-eth-1182</loc>
@@ -6039,7 +6039,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/its-planned-1186</loc>
@@ -6047,7 +6047,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/focal-point-for-ranked-lists-1187</loc>
@@ -6055,7 +6055,7 @@
             2019-01-07
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tracyspacy/a-brief-observation-of-various-consensus-algorithms-1188</loc>
@@ -6063,7 +6063,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-story-chapter-3-1189</loc>
@@ -6071,7 +6071,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/demand-driven-development-1190</loc>
@@ -6079,7 +6079,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/the-process-of-merge-minging-and-how-it-works-1192</loc>
@@ -6087,7 +6087,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/simple-bitcoin-wallet-006-supports-op_returns-1194</loc>
@@ -6095,7 +6095,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/title-is-too-short-1195</loc>
@@ -6103,7 +6103,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-bombs-gaza-us-troops-leaving-syria-going-to-iraq-instead-of-home-and-us-deploys-to-congo-1196</loc>
@@ -6111,7 +6111,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/investing-tip-try-coin-to-coin-exchange-1197</loc>
@@ -6119,7 +6119,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/spooky/i-need-foods-house-medicines-cloths-1198</loc>
@@ -6127,7 +6127,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/i-took-the-week-off-1199</loc>
@@ -6135,7 +6135,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/brave-browser-and-bat-token-1200</loc>
@@ -6143,7 +6143,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/ideas-bundled-vs-unbundled-1201</loc>
@@ -6151,7 +6151,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Phantom/multi-coin-wallet-1202</loc>
@@ -6159,7 +6159,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Phantom/seed-is-the-same-1205</loc>
@@ -6167,7 +6167,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Phantom/seed-is-the-different-1206</loc>
@@ -6175,7 +6175,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/one-of-my-favorite-shots-from-a-tv-show-1207</loc>
@@ -6183,7 +6183,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/the-most-valuable-order-1208</loc>
@@ -6191,7 +6191,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/allkeyscash-all-bitcoin-cash-private-keys-1209</loc>
@@ -6199,7 +6199,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CryptoWarRoom/hello-world-1213</loc>
@@ -6207,7 +6207,7 @@
             2019-01-08
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BigBlockIfTrue/bch-ux-suggestion-mandatory-cashaddr-for-p2sh-1214</loc>
@@ -6215,7 +6215,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/prioritizing-improvement-1216</loc>
@@ -6223,7 +6223,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-novel-chapter-4-1218</loc>
@@ -6231,7 +6231,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TheOneLaw/harm-is-an-act-unaccepted-by-whom-it-impacts-1219</loc>
@@ -6239,7 +6239,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/vermorel-claims-cash-db-can-process-close-to-20000-transactions-per-second-1220</loc>
@@ -6247,7 +6247,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/blockchain-industry-the-most-popular-women-in-cryptocurrency-1273</loc>
@@ -6255,7 +6255,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/bitcoin-atms-continue-to-spread-across-the-globe-1276</loc>
@@ -6263,7 +6263,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/block-your-dates-the-north-american-bitcoin-conference-is-all-set-to-ignite-miami-1278</loc>
@@ -6271,7 +6271,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/talking-about-the-discrete-logarithm-problem-has-never-gotten-me-laid-1281</loc>
@@ -6279,7 +6279,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/title-is-too-short-1283</loc>
@@ -6287,7 +6287,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/title-is-too-short-1286</loc>
@@ -6295,7 +6295,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/ed-buck-strikes-again-forced-2nd-anti-bds-vote-new-ksa-us-missile-defense-and-more-us-al-qaeda-ties-1295</loc>
@@ -6303,7 +6303,7 @@
             2019-01-09
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/odbdb/re-the-long-game-of-the-btc-is-now-evident-in-the-market-an-autopsy-1296</loc>
@@ -6311,7 +6311,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/re-quality-over-quantity-high-aspirations-1298</loc>
@@ -6319,7 +6319,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/honest-cashs-1-priority-1300</loc>
@@ -6327,7 +6327,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/re-love-it_________-1302</loc>
@@ -6335,7 +6335,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/the-vision-of-the-nightingale-1303</loc>
@@ -6343,7 +6343,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/influence-equal-vs-unequal-1304</loc>
@@ -6351,7 +6351,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/show-responses-in-feed-please-1305</loc>
@@ -6359,7 +6359,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/crowdfunded-advertising-1306</loc>
@@ -6367,7 +6367,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/re-influence-equal-vs-unequal-1307</loc>
@@ -6375,7 +6375,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/cream-rises-to-the-top-1308</loc>
@@ -6383,7 +6383,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/btw-yours-is-back-1309</loc>
@@ -6391,7 +6391,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/fund-providers-insist-theres-enough-market-liquidity-for-a-bitcoin-etf-1311</loc>
@@ -6399,7 +6399,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/only-seven-exchanges-passed-government-security-inspection-in-south-korea-1312</loc>
@@ -6407,7 +6407,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/nick-szabo-central-banks-may-turn-to-cryptocurrency-reserves-over-gold-1313</loc>
@@ -6415,7 +6415,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-title-is-too-short-1315</loc>
@@ -6423,7 +6423,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-1-upvote-editing-disabled-criticism-and-critique-is-appreciation-1316</loc>
@@ -6431,7 +6431,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/a-riddle-for-honestcash-1317</loc>
@@ -6439,7 +6439,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/re-cream-rises-to-the-top-1318</loc>
@@ -6447,7 +6447,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/re-btw-yours-is-back-1319</loc>
@@ -6455,7 +6455,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-1-upvote-editing-disabled-criticism-and-critique-is-appreciation-1321</loc>
@@ -6463,7 +6463,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-title-is-too-short-1322</loc>
@@ -6471,7 +6471,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/how-short-1323</loc>
@@ -6479,7 +6479,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-btw-yours-is-back-1324</loc>
@@ -6487,7 +6487,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/the-proof-is-in-the-pudding-1325</loc>
@@ -6495,7 +6495,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/re-the-proof-is-in-the-pudding-1326</loc>
@@ -6503,7 +6503,7 @@
             2019-01-10
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/mattcriptoactivos/mimblewimble-and-beam-1329</loc>
@@ -6511,7 +6511,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Coins4Clothes/coins-4-clothes-a-look-back-at-our-first-year-1331</loc>
@@ -6519,7 +6519,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/report-claims-chinese-mining-giant-bitmain-is-prepping-for-new-leadership-1332</loc>
@@ -6527,7 +6527,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/china-announces-new-regulations-for-blockchain-companies-to-promote-healthy-development-1333</loc>
@@ -6535,7 +6535,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Shinigami/china-announcement-for-blockchain-companies-for-healthy-development-1334</loc>
@@ -6543,7 +6543,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Shinigami/found-only-genuine-app-which-pays-in-android-instantly-1335</loc>
@@ -6551,7 +6551,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/what-wow-d-1336</loc>
@@ -6559,7 +6559,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/censorship-paypal-mastercard-visa-patreon-discover-1337</loc>
@@ -6567,7 +6567,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Shinigami/terra-launches-mongolias-first-blockchain-payment-system-1338</loc>
@@ -6575,7 +6575,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-show-responses-in-feed-please-1340</loc>
@@ -6583,7 +6583,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/re-re-show-responses-in-feed-please-1341</loc>
@@ -6591,7 +6591,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Shinigami/swedens-central-bank-issues-warning-1342</loc>
@@ -6599,7 +6599,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chicken/ecip-1049-why-ethereum-classic-should-adopt-keccak256-for-its-proof-of-work-algorithm-1343</loc>
@@ -6607,7 +6607,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/unesco-world-heritage-site-the-humayuns-tomb-new-delhi-india-1344</loc>
@@ -6615,7 +6615,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/will-the-us-navy-help-you-fall-asleep-in-2-minutes-and-sleep-better-and-faster-in-2019-1345</loc>
@@ -6623,7 +6623,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/re-honest-cashs-1-priority-sorting-comments-1346</loc>
@@ -6631,7 +6631,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/re-btw-yours-is-back-1347</loc>
@@ -6639,7 +6639,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-re-show-responses-in-feed-please-1349</loc>
@@ -6647,7 +6647,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/sorting-comments-1350</loc>
@@ -6655,7 +6655,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/MaelstrohmBlack/i-wish-you-all-a-happy-new-year-nows-a-great-time-to-earn-back-on-all-you-spent-during-the-holidays-discover-the-cent-platform-1351</loc>
@@ -6663,7 +6663,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/MaelstrohmBlack/re-i-wish-you-all-a-happy-new-year-nows-a-great-time-to-earn-back-on-all-you-spent-during-the-holidays-discover-the-cent-platform-1352</loc>
@@ -6671,7 +6671,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-will-the-us-navy-help-you-fall-asleep-in-2-minutes-and-sleep-better-and-faster-in-2019-1353</loc>
@@ -6679,7 +6679,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-neo-1354</loc>
@@ -6687,7 +6687,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/HLife88/cryptocurrency-chronicles-1tales-of-a-noob-1355</loc>
@@ -6695,7 +6695,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Shinigami/have-you-tried-cent-1356</loc>
@@ -6703,7 +6703,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/fiat-iustitia-et-pereat-mundus-or-may-justice-for-groups-never-deny-it-for-individuals-a-poetic-interpretation-1357</loc>
@@ -6711,7 +6711,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-btw-yours-is-back-1358</loc>
@@ -6719,7 +6719,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/our-great-african-bank-heist-spurred-my-small-anyana-skeleton-poem-to-the-icons-of-our-struggle-1359</loc>
@@ -6727,7 +6727,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-nature-a-phenom-by-design-a-poetic-piece-1360</loc>
@@ -6735,7 +6735,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/indian-bank-forcing-customers-to-agree-to-anti-cryptocurrency-policy-1361</loc>
@@ -6743,7 +6743,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/hello-cent-im-going-to-blog-my-learning-you-1362</loc>
@@ -6751,7 +6751,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BCH/phi-1618-golden-mean-ratio-1363</loc>
@@ -6759,7 +6759,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JakeMcC/turning-a-simple-game-in-to-something-special-1365</loc>
@@ -6767,7 +6767,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nicewoody69/re-re-nature-a-phenom-by-design-a-poetic-piece-1366</loc>
@@ -6775,7 +6775,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Phantom/re-prioritizing-improvement-1367</loc>
@@ -6783,7 +6783,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nicewoody69/magic-a-poetic-piece-1368</loc>
@@ -6791,7 +6791,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/DrCryptoNL/smoking-weed-on-honestcash-1369</loc>
@@ -6799,7 +6799,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptocrazy/nasa-telescope-helped-examine-mysterious-blast-called-holy-cow-1370</loc>
@@ -6807,7 +6807,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Phantom/re-smoking-weed-on-honestcash-1371</loc>
@@ -6815,7 +6815,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptocrazy/time-lapse-of-the-entire-universe-1372</loc>
@@ -6823,7 +6823,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/the-salt-vs-ethlend-cryptocurrency-platform-comparison-1373</loc>
@@ -6831,7 +6831,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptocrazy/re-the-first-uncensorable-story-on-honest-cash-1374</loc>
@@ -6839,7 +6839,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/vaccineautism-link-confirmed-france-seeks-to-make-protests-illegal-and-newsguards-war-on-alt-media-1375</loc>
@@ -6847,7 +6847,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/LizbethAlviarez/use-of-cryptocurrencies-in-venezuela-and-the-work-being-done-by-the-bitcoin-cash-community-in-our-country-for-a-true-adoption-of-the-currency-1377</loc>
@@ -6855,7 +6855,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/LizbethAlviarez/uso-de-las-criptomonedas-en-venezuela-y-el-trabajo-que-esta-realizando-la-comunidad-bitcoin-cash-en-nuestro-pais-para-una-verdadera-adopcion-de-la-moneda-1378</loc>
@@ -6863,7 +6863,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/HLife88/re-frequently-asked-questions-1379</loc>
@@ -6871,7 +6871,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/HLife88/re-bitcoin-cash-in-crisis-lies-opportunity-1380</loc>
@@ -6879,7 +6879,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dreadk/honest-cash-start-1381</loc>
@@ -6887,7 +6887,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/HLife88/re-cryptocurrency-chronicles-1tales-of-a-noob-1382</loc>
@@ -6895,7 +6895,7 @@
             2019-01-11
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/starting-with-yours-to-honest-and-cent-1383</loc>
@@ -6903,7 +6903,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/bookmarking-new-site-to-delete-my-patreon-1384</loc>
@@ -6911,7 +6911,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-1-upvote-editing-disabled-criticism-and-critique-is-appreciation-1385</loc>
@@ -6919,7 +6919,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/i-believe-that-hc-will-be-different-wonderfully-different-1386</loc>
@@ -6927,7 +6927,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-two-suggestions-delete-posts-and-timestamps-1387</loc>
@@ -6935,7 +6935,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/title-change-testing-1388</loc>
@@ -6943,7 +6943,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/so-cool-honest-follows-suit-with-memo-1389</loc>
@@ -6951,7 +6951,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-so-cool-honest-follows-suit-with-memo-1390</loc>
@@ -6959,7 +6959,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/ok-im-just-going-to-assume-it-goes-deep-1391</loc>
@@ -6967,7 +6967,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/how-far-curiosity-killed-the-cat-1392</loc>
@@ -6975,7 +6975,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-how-far-curiosity-killed-the-cat-1393</loc>
@@ -6983,7 +6983,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/after-5-responses-deep-load-more-replies-1394</loc>
@@ -6991,7 +6991,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-novel-chapter-45-1395</loc>
@@ -6999,7 +6999,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jhayehidio/introduce-yourself-jhay-ehidio-1396</loc>
@@ -7007,7 +7007,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/the-nav-coin-blockchain-review-1397</loc>
@@ -7015,7 +7015,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/privacy-in-a-cryptocurrency-maybe-not-1398</loc>
@@ -7023,7 +7023,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/we-dont-take-orders-from-bolton-says-military-israel-seeks-me-reparations-and-yemen-fights-back-1399</loc>
@@ -7031,7 +7031,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/ill-take-my-social-business-elsewhere-cent-1400</loc>
@@ -7039,7 +7039,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/re-openbazaar-freedom-simplified-1401</loc>
@@ -7047,7 +7047,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/re-honestcash-wallet-update-1402</loc>
@@ -7055,7 +7055,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/MobTwo/re-re-bitcoin-cash-in-crisis-lies-opportunity-1403</loc>
@@ -7063,7 +7063,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/first-impression-peepeth-patreon-but-upfront-about-it-1404</loc>
@@ -7071,7 +7071,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-wallets-on-honest-cash-1405</loc>
@@ -7079,7 +7079,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/bitcoin-will-cross-dollar10000-by-april-2019-1407</loc>
@@ -7087,7 +7087,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ridedonkeys/will-2019-be-the-year-of-virtual-reality-vr-1408</loc>
@@ -7095,7 +7095,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-doge-1409</loc>
@@ -7103,7 +7103,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Richmond3047/make-me-the-reason-1410</loc>
@@ -7111,7 +7111,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-smoking-weed-on-honestcash-1411</loc>
@@ -7119,7 +7119,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-4-suggestions-delete-posts-timestamps-notifications-and-edit-history-1412</loc>
@@ -7127,7 +7127,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-ill-take-my-social-business-elsewhere-cent-1413</loc>
@@ -7135,7 +7135,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-re-honestcash-wallet-update-1414</loc>
@@ -7143,7 +7143,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/poetry-in-crosstitution-rips-or-thuma-mina-im-ready-1417</loc>
@@ -7151,7 +7151,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dayitva/earn-cryptocurrency-for-free-using-coinpot-1418</loc>
@@ -7159,7 +7159,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/re-crypto-characters-doge-1419</loc>
@@ -7167,7 +7167,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/re-re-crypto-characters-doge-1420</loc>
@@ -7175,7 +7175,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AtomCollector/introducing-myself-1421</loc>
@@ -7183,7 +7183,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-steem-1422</loc>
@@ -7191,7 +7191,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/re-stormy-coastal-landscape-thunder-cloud-and-rain-1423</loc>
@@ -7199,7 +7199,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-attacks-syria-again-gaza-retaliates-after-israel-attack-and-5500-us-backed-syrian-mercenaries-1425</loc>
@@ -7207,7 +7207,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BCH/banks-fined-for-money-laundering-from-bitcoincom-moved-to-here-by-a-guy-called-robert-lefebure-1426</loc>
@@ -7215,7 +7215,7 @@
             2019-01-12
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Lematt/osmonaute-animation-short-film-1427</loc>
@@ -7223,7 +7223,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/re-re-wallets-on-honest-cash-1428</loc>
@@ -7231,7 +7231,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/re-re-re-crypto-characters-doge-1430</loc>
@@ -7239,7 +7239,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/re-new-chillandcrowdfund-channel-new-video-1431</loc>
@@ -7247,7 +7247,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/re-osmonaute-animation-short-film-1433</loc>
@@ -7255,7 +7255,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/new-to-bat-read-this-introduction-to-basic-attention-token-bat-1436</loc>
@@ -7263,7 +7263,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/re-re-re-honestcash-wallet-update-1437</loc>
@@ -7271,7 +7271,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Anthy/my-first-post-1438</loc>
@@ -7279,7 +7279,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/re-bch-ux-suggestion-mandatory-cashaddr-for-p2sh-1439</loc>
@@ -7287,7 +7287,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/re-can-cloud-mining-make-you-rich-1441</loc>
@@ -7295,7 +7295,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Anthy/re-making-double-spending-0-conf-with-bitcoin-sv-1442</loc>
@@ -7303,7 +7303,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/see-comment-when-replying-1443</loc>
@@ -7311,7 +7311,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/kklewis57/eight-facts-you-need-to-know-about-bitcoins-1444</loc>
@@ -7319,7 +7319,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/determining-the-importance-of-things-1445</loc>
@@ -7327,7 +7327,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/the-economics-of-music-1446</loc>
@@ -7335,7 +7335,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-novel-chapter-6-1447</loc>
@@ -7343,7 +7343,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/re-re-re-re-crypto-characters-doge-1448</loc>
@@ -7351,7 +7351,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/electron-cash-plugin-template-1449</loc>
@@ -7359,7 +7359,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-sec-1450</loc>
@@ -7367,7 +7367,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/electron-cash-coinsplitter-plugin-an-bsv-plugin-1451</loc>
@@ -7375,7 +7375,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/re-crypto-characters-sec-1452</loc>
@@ -7383,7 +7383,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/bitcoin-history-part-1-in-the-beginning-1453</loc>
@@ -7391,7 +7391,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/pow-pos-dpos-the-beginners-guide-1454</loc>
@@ -7399,7 +7399,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-4-suggestions-delete-posts-timestamps-notifications-and-edit-history-1455</loc>
@@ -7407,7 +7407,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-smoking-weed-on-honestcash-1456</loc>
@@ -7415,7 +7415,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/re-re-crypto-characters-sec-1457</loc>
@@ -7423,7 +7423,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/a-guide-to-cryptocurrency-bot-1458</loc>
@@ -7431,7 +7431,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/cant-log-in-to-my-patreon-1459</loc>
@@ -7439,7 +7439,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/danigocrypto/re-re-re-re-re-crypto-characters-doge-1460</loc>
@@ -7447,7 +7447,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/protection-from-criminals-to-help-the-government-fight-1461</loc>
@@ -7455,7 +7455,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Madstudios/there-is-room-under-the-tent-for-everyone-1462</loc>
@@ -7463,7 +7463,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/cryptocurrency-law-firms-currently-available-1463</loc>
@@ -7471,7 +7471,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/peak_fud/re-electron-cash-plugin-template-1464</loc>
@@ -7479,7 +7479,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/re-re-electron-cash-plugin-template-1465</loc>
@@ -7487,7 +7487,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/IudexOfSimias/do-you-share-my-need-1467</loc>
@@ -7495,7 +7495,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/HLife88/re-electron-cash-plugin-template-1468</loc>
@@ -7503,7 +7503,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/IudexOfSimias/be-wary-of-attention-1469</loc>
@@ -7511,7 +7511,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-re-re-wallets-on-honest-cash-1470</loc>
@@ -7519,7 +7519,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-confirms-unprovoked-syria-attack-mcconnells-third-anti-bds-vote-and-house-anti-semitism-bill-1471</loc>
@@ -7527,7 +7527,7 @@
             2019-01-13
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/bitcoincast/bringing-bch-adoption-to-punk-markets-1475</loc>
@@ -7535,7 +7535,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/the-birth-or-a-poem-by-oodeyaa-1476</loc>
@@ -7543,7 +7543,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/think-we-need-gov-support-freesocietycom-1480</loc>
@@ -7551,7 +7551,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/re-re-ill-take-my-social-business-elsewhere-cent-1481</loc>
@@ -7559,7 +7559,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-introducing-myself-1482</loc>
@@ -7567,7 +7567,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/market-websites-vs-democratic-websites-1484</loc>
@@ -7575,7 +7575,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-magic-a-poetic-piece-1485</loc>
@@ -7583,7 +7583,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/we-have-posts-and-responses-tabs-1486</loc>
@@ -7591,7 +7591,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/lubokkanev/re-huge-bch-adoption-opportunity-in-punk-markets-1487</loc>
@@ -7599,7 +7599,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AtomCollector/re-re-introducing-myself-1488</loc>
@@ -7607,7 +7607,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-bank-1489</loc>
@@ -7615,7 +7615,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chainxor/re-huge-bch-adoption-opportunity-in-punk-markets-1492</loc>
@@ -7623,7 +7623,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/indusrush/a-singer-with-throat-cancer-1-1493</loc>
@@ -7631,7 +7631,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/projects-and-ideas-2019-01-14-1495</loc>
@@ -7639,7 +7639,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/aclcrypto/building-in-decentraland-1496</loc>
@@ -7647,7 +7647,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/aclcrypto/for-sale-buildings-for-decentraland-1497</loc>
@@ -7655,7 +7655,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Madstudios/carnival-by-dibble-artworks-1499</loc>
@@ -7663,7 +7663,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/re-update-upvote-transactions-stored-on-chain-and-open-call-to-bitcoin-explorers-1500</loc>
@@ -7671,7 +7671,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/re-projects-and-ideas-2019-01-14-1501</loc>
@@ -7679,7 +7679,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/re-re-update-upvote-transactions-stored-on-chain-and-open-call-to-bitcoin-explorers-1502</loc>
@@ -7687,7 +7687,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/alphalim/a-prayer-for-the-hour-of-rush-1503</loc>
@@ -7695,7 +7695,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/re-re-projects-and-ideas-2019-01-14-1504</loc>
@@ -7703,7 +7703,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chicken/re-just-one-more-leap-of-faith-1505</loc>
@@ -7711,7 +7711,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/re-re-just-one-more-leap-of-faith-1506</loc>
@@ -7719,7 +7719,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/saddit42/re-re-projects-and-ideas-2019-01-14-1508</loc>
@@ -7727,7 +7727,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/bitcoin-cashaccounts-explained-withdemo-1511</loc>
@@ -7735,7 +7735,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/using-money-to-rank-books-1512</loc>
@@ -7743,7 +7743,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dreadk/venezuela-in-search-of-its-new-freedom-1513</loc>
@@ -7751,7 +7751,7 @@
             2019-01-14
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/price-inflation-vs-supply-inflation-1514</loc>
@@ -7759,7 +7759,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/smashing-the-echo-chamber-1515</loc>
@@ -7767,7 +7767,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/re-re-re-projects-and-ideas-2019-01-14-1517</loc>
@@ -7775,7 +7775,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/FUBAR165/we-need-a-cryptocurrency-version-of-the-send-a-beer-to-a-furloughed-federal-worker-1518</loc>
@@ -7783,7 +7783,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/bitcoin-history-part-2-the-bitcoin-symbol-1519</loc>
@@ -7791,7 +7791,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/hussain-albukhaiti-interview-the-us-backed-saudi-coalitions-fake-ceasefire-and-support-of-terrorism-1520</loc>
@@ -7799,7 +7799,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Falopeolakunle/how-asuu-academic-staff-union-of-universities-is-affecting-students-in-nigeria-through-strike-by-keeping-students-at-home-1523</loc>
@@ -7807,7 +7807,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Falopeolakunle/pdp-peoples-democratic-party-apc-all-progressive-congress-and-how-corrupt-they-are-to-nigerians-and-the-incoming-presidential-election-of-nigeria-2019-1524</loc>
@@ -7815,7 +7815,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-hash-1526</loc>
@@ -7823,7 +7823,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Iadetunji/how-i-earned-my-1st-bitcoin-1527</loc>
@@ -7831,7 +7831,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/honest-isnt-better-than-cent-for-everyone-1529</loc>
@@ -7839,7 +7839,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/telegram-popular-non-anti-bot-faucets-1531</loc>
@@ -7847,7 +7847,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/skycoin-vs-eth-1532</loc>
@@ -7855,7 +7855,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/philo-sophielove-1533</loc>
@@ -7863,7 +7863,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/introducing-the-aea-to-msws-1537</loc>
@@ -7871,7 +7871,7 @@
             2019-01-15
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darwin/bitcoin-cash-dev-meeting-jan-17-2019-1539</loc>
@@ -7879,7 +7879,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Anthy/re-whats-coming-for-honest-in-the-next-days-recommendations-1542</loc>
@@ -7887,7 +7887,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-novel-chapter-7-1544</loc>
@@ -7895,7 +7895,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/my-love-waiting-for-your-reply-1545</loc>
@@ -7903,7 +7903,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/blockstream-sellouts-credit-cards-greater-crypto-1546</loc>
@@ -7911,7 +7911,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Dasterdly/re-just-one-more-leap-of-faith-1547</loc>
@@ -7919,7 +7919,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/trump-says-syria-war-not-ending-congress-introduces-another-israel-aid-bill-and-pompeo-utterly-lies-1548</loc>
@@ -7927,7 +7927,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/honest-cash-vs-bitbackerio-1549</loc>
@@ -7935,7 +7935,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Yasu24/nice-to-meet-you-honestecash-this-article-is-my-first-post-1550</loc>
@@ -7943,7 +7943,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/re-the-intrinsic-value-of-bitcoin-1552</loc>
@@ -7951,7 +7951,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/add-the-option-to-delete-posts-1553</loc>
@@ -7959,7 +7959,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-blockchain-1554</loc>
@@ -7967,7 +7967,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/instrucciones-para-recibir-y-dar-propinas-en-bitcoin-cash-con-utippr-reddit-1555</loc>
@@ -7975,7 +7975,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/-ed-defends-socialism-1557</loc>
@@ -7983,7 +7983,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/what-the-hell-is-going-on-with-brexit-1561</loc>
@@ -7991,7 +7991,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/gillette-the-falling-monopoly-1563</loc>
@@ -7999,7 +7999,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/finding-the-right-consensus-algorithm-1565</loc>
@@ -8007,7 +8007,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Blessedmomma4/pushing-pray-until-some-thing-happens-1568</loc>
@@ -8015,7 +8015,7 @@
             2019-01-16
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AD1AD/say-yes-to-paypal-20-1570</loc>
@@ -8023,7 +8023,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/phabulu/bitcoin-10-years-challenge-1571</loc>
@@ -8031,7 +8031,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/venezuela-in-us-crosshairs-isis-kills-4-us-troops-in-syria-and-us-journalist-indefinitely-detained-1573</loc>
@@ -8039,7 +8039,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emrosedallara/re-add-the-option-to-delete-posts-1574</loc>
@@ -8047,7 +8047,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/re-re-add-the-option-to-delete-posts-1575</loc>
@@ -8055,7 +8055,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-miner-1576</loc>
@@ -8063,7 +8063,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/doubt-about-income-from-upvotes-in-my-posts-1577</loc>
@@ -8071,7 +8071,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emrosedallara/re-i-mean-that-each-user-can-delete-their-own-posts-1579</loc>
@@ -8079,7 +8079,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/aclcrypto/binance-jersey-offers-fiat-crypto-exchange-rewards-1581</loc>
@@ -8087,7 +8087,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/technical-how-does-the-new-honest-feed-algorithm-work-1582</loc>
@@ -8095,7 +8095,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/wired-bch-transactions-1583</loc>
@@ -8103,7 +8103,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yhelliee/re-frequently-asked-questions-1584</loc>
@@ -8111,7 +8111,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yhelliee/my-first-post-1585</loc>
@@ -8119,7 +8119,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/OrangeJuice/re-add-the-option-to-delete-posts-1586</loc>
@@ -8127,7 +8127,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Money78/re-my-first-post-1587</loc>
@@ -8135,7 +8135,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/MobTwo/going-back-in-time-to-buy-bitcoin-at-dollar100-1588</loc>
@@ -8143,7 +8143,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/the-impatient-dromedary-1589</loc>
@@ -8151,7 +8151,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/re-honest-cash-vs-bitbackerio-1590</loc>
@@ -8159,7 +8159,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/invest-in-lego-sets-1591</loc>
@@ -8167,7 +8167,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/ive-been-a-gambler-most-of-my-life-1592</loc>
@@ -8175,7 +8175,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-pizza-1593</loc>
@@ -8183,7 +8183,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/substantial-and-specific-feedback-1594</loc>
@@ -8191,7 +8191,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/seeing-bitvotes-in-feed-1595</loc>
@@ -8199,7 +8199,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/happy-customers-profit-and-fun-invitation-to-penguin-copyleft-and-micro-payment-social-networks-1597</loc>
@@ -8207,7 +8207,7 @@
             2019-01-17
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tracyspacy/5-questions-to-bitcoin-cash-community-1598</loc>
@@ -8215,7 +8215,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/re-5-questions-to-bitcoin-cash-community-1599</loc>
@@ -8223,7 +8223,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/how-do-you-identify-politically-1601</loc>
@@ -8231,7 +8231,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/the-best-of-luck-to-honest-cash-1602</loc>
@@ -8239,7 +8239,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/this-is-how-the-option-to-record-onchain-content-in-honest-cash-works-1603</loc>
@@ -8247,7 +8247,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/13-interconneected-social-networks-yours-sola-castbox-audiopodcast-with-pauseandlinking-honest-cent-weku-ello-steemit-minds-bitbacker-chaturbate-pornhub-memo-1604</loc>
@@ -8255,7 +8255,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/possibility-of-posting-comments-without-title-1606</loc>
@@ -8263,7 +8263,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/syria-bombing-used-to-keep-us-in-syria-us-inf-lies-and-family-cleaning-park-removed-for-no-permit-1607</loc>
@@ -8271,7 +8271,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/FUBAR165/where-to-go-for-ideas-for-cryptocurrency-products-1608</loc>
@@ -8279,7 +8279,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/scriptSig/re-where-to-go-for-ideas-for-cryptocurrency-products-1609</loc>
@@ -8287,7 +8287,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-technical-how-does-the-new-honest-feed-algorithm-work-1610</loc>
@@ -8295,7 +8295,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/its-all-about-the-execution-1612</loc>
@@ -8303,7 +8303,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/maybe-we-should-not-rule-out-advertising-altogether-1613</loc>
@@ -8311,7 +8311,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/cats-of-istanbul-in-istanbul-an-ordinary-kedi-lives-an-extraordinary-life-1614</loc>
@@ -8319,7 +8319,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/i-prefer-an-autonomous-and-native-system-1615</loc>
@@ -8327,7 +8327,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/sharing-ideas-about-honestcash-1616</loc>
@@ -8335,7 +8335,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/i-propose-that-logging-in-with-the-seed-be-optional-1617</loc>
@@ -8343,7 +8343,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emrosedallara/re-where-to-go-for-ideas-for-cryptocurrency-products-1618</loc>
@@ -8351,7 +8351,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/i-agree-with-you-1619</loc>
@@ -8359,7 +8359,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/re-where-to-go-for-ideas-for-cryptocurrency-products-1620</loc>
@@ -8367,7 +8367,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/probando-probando-probando-1621</loc>
@@ -8375,7 +8375,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/and-i-can-log-in-now-1622</loc>
@@ -8383,7 +8383,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-re-technical-how-does-the-new-honest-feed-algorithm-work-1625</loc>
@@ -8391,7 +8391,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/i-identify-myself-as-a-libertarian-1627</loc>
@@ -8399,7 +8399,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/the-upvotes-are-sent-to-the-address-that-was-specified-in-your-profile-1628</loc>
@@ -8407,7 +8407,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/my-problem-has-been-solved-thank-you-1629</loc>
@@ -8415,7 +8415,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/re-honest-cash-just-became-more-transparent-1630</loc>
@@ -8423,7 +8423,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Telesfor/re-unzureichendes-gleichgewicht-1631</loc>
@@ -8431,7 +8431,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/re-show-responses-in-feed-please-1634</loc>
@@ -8439,7 +8439,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/pow-pos-dpos-the-beginners-guide-1637</loc>
@@ -8447,7 +8447,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/bypassing-vietnams-crypto-blockage-with-otc-platforms-1638</loc>
@@ -8455,7 +8455,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/a-cold-crypto-wallet-will-be-the-legacy-i-leave-for-my-daughter-1639</loc>
@@ -8463,7 +8463,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/push-down-trash-or-pull-up-treasure-1640</loc>
@@ -8471,7 +8471,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/puede-honest-cash-reemplazar-a-yoursorg-1641</loc>
@@ -8479,7 +8479,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/smokeio-off-topic-not-allowed-1642</loc>
@@ -8487,7 +8487,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/OrangeJuice/re-whats-coming-for-honest-in-the-next-days-recommendations-1643</loc>
@@ -8495,7 +8495,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/whole-crypto-marketplace-being-manipulated-at-once-1645</loc>
@@ -8503,7 +8503,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/a-small-bowlful-of-pot-1646</loc>
@@ -8511,7 +8511,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AsashoryuMaryBerry/re-re-show-responses-in-feed-please-1647</loc>
@@ -8519,7 +8519,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptocrazy/go-and-buy-bitcoin-at-some-grocery-stores-in-us-1648</loc>
@@ -8527,7 +8527,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-novel-chapter-8-1649</loc>
@@ -8535,7 +8535,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/ownership-vs-possession-1650</loc>
@@ -8543,7 +8543,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/journalist-jailed-for-yellow-vest-support-us-caught-training-uae-in-yemen-and-msm-child-sexualization-1653</loc>
@@ -8551,7 +8551,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jsabastine/re-a-cold-crypto-wallet-will-be-the-legacy-i-leave-for-my-daughter-1654</loc>
@@ -8559,7 +8559,7 @@
             2019-01-18
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/want-to-earn-interest-on-your-bitcoin-cash-1655</loc>
@@ -8567,7 +8567,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/does-honest-cash-fill-in-the-gap-left-by-yours-1656</loc>
@@ -8575,7 +8575,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/re-whole-crypto-marketplace-being-manipulated-at-once-1657</loc>
@@ -8583,7 +8583,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/smokeio-vs-honest-cash-1658</loc>
@@ -8591,7 +8591,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/photography-friday-1659</loc>
@@ -8599,7 +8599,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/yours-is-now-an-inactive-bsv-platform-1660</loc>
@@ -8607,7 +8607,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/introducing-dan-kopf-to-honest-cash-1661</loc>
@@ -8615,7 +8615,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/jacobsonbwj/extremely-good-guitarist-shredding-1662</loc>
@@ -8623,7 +8623,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/honestcash-implemented-in-bitcoincom-1664</loc>
@@ -8631,7 +8631,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/saturday-afternoon-1665</loc>
@@ -8639,7 +8639,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/delayed-weed-knockout-is-that-a-thing-1666</loc>
@@ -8647,7 +8647,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/re-re-honest-cash-just-became-more-transparent-1668</loc>
@@ -8655,7 +8655,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/anarcho-capitalism-1669</loc>
@@ -8663,7 +8663,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/the-expectations-around-cashaddr-1670</loc>
@@ -8671,7 +8671,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-honestcash-implemented-in-bitcoincom-1671</loc>
@@ -8679,7 +8679,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Jack86/new-to-crypto-looking-for-help-1673</loc>
@@ -8687,7 +8687,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/alphalim/what-is-a-man-a-response-to-gillette-1675</loc>
@@ -8695,7 +8695,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/-1676</loc>
@@ -8703,7 +8703,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/re-new-to-crypto-looking-for-help-1677</loc>
@@ -8711,7 +8711,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/thethrowaccount21/fair-value-and-bch-1678</loc>
@@ -8719,7 +8719,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Logan/why-do-we-hate-adds-so-much-1680</loc>
@@ -8727,7 +8727,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Logan/re-honestcash-implemented-in-bitcoincom-1681</loc>
@@ -8735,7 +8735,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yukiteruamano/un-comienzo-1683</loc>
@@ -8743,7 +8743,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/daydreaming-rosa-1684</loc>
@@ -8751,7 +8751,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SILENTSAM/re-delayed-weed-knockout-is-that-a-thing-1685</loc>
@@ -8759,7 +8759,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/calisi/re-how-do-you-identify-politically-1686</loc>
@@ -8767,7 +8767,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/OrangeJuice/re-whats-coming-for-honest-in-the-next-days-recommendations-1688</loc>
@@ -8775,7 +8775,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/bienvenido-a-la-comunidad-bch-1689</loc>
@@ -8783,7 +8783,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/honest_cash/how-to-import-your-honest-wallet-into-bitcoincom-wallet-1690</loc>
@@ -8791,7 +8791,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/rkalis/re-cats-of-istanbul-in-istanbul-an-ordinary-kedi-lives-an-extraordinary-life-1691</loc>
@@ -8799,7 +8799,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/the-whistling-girl-1692</loc>
@@ -8807,7 +8807,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/btcven/re-why-do-we-hate-adds-so-much-1693</loc>
@@ -8815,7 +8815,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Logan/re-re-why-do-we-hate-adds-so-much-1694</loc>
@@ -8823,7 +8823,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/whotippedit/honestwhotippedit-1695</loc>
@@ -8831,7 +8831,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/re-honestwhotippedit-1696</loc>
@@ -8839,7 +8839,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/re-re-honestcash-implemented-in-bitcoincom-1697</loc>
@@ -8847,7 +8847,7 @@
             2019-01-19
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/attention-all-xlm-holders-1699</loc>
@@ -8855,7 +8855,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-shoots-2-journalists-us-coalition-kills-20-fleeing-syrian-civilians-and-freemarziehhashemi-1700</loc>
@@ -8863,7 +8863,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nogriv/first-day-in-honestcash-a-little-opinion-1701</loc>
@@ -8871,7 +8871,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-the-whistling-girl-1702</loc>
@@ -8879,7 +8879,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/alrashel/nightmare-on-a-day-light-1703</loc>
@@ -8887,7 +8887,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BCH/httpwwwfractaleconomicsnet-dan-winter-ref-1704</loc>
@@ -8895,7 +8895,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-honestwhotippedit-1705</loc>
@@ -8903,7 +8903,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/terrace-house-opening-new-doors-netflix-review-1706</loc>
@@ -8911,7 +8911,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/difference-drives-progress-1707</loc>
@@ -8919,7 +8919,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/i-do-not-see-any-information-1708</loc>
@@ -8927,7 +8927,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-i-do-not-see-any-information-1710</loc>
@@ -8935,7 +8935,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/feed-notifications-1711</loc>
@@ -8943,7 +8943,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/whotippedit/re-i-do-not-see-any-information-1712</loc>
@@ -8951,7 +8951,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/bitcoin-cash-notes-1713</loc>
@@ -8959,7 +8959,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/smokeio-offtopic-offensive-1714</loc>
@@ -8967,7 +8967,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/whotippedit/re-re-honestwhotippedit-1715</loc>
@@ -8975,7 +8975,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/whotippedit/re-re-honestwhotippedit-1716</loc>
@@ -8983,7 +8983,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Intisar/treat-yourself-like-someone-you-loved-1717</loc>
@@ -8991,7 +8991,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/OrangeJuice/re-bitcoin-cash-notes-1719</loc>
@@ -8999,7 +8999,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/re-re-bitcoin-cash-notes-1720</loc>
@@ -9007,7 +9007,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/-1721</loc>
@@ -9015,7 +9015,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/painting-that-given-me-huge-recognition-among-the-artist-community-of-my-city-1722</loc>
@@ -9023,7 +9023,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-novel-chapter-9-1723</loc>
@@ -9031,7 +9031,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitwise/can-hc-survive-without-censorship-1725</loc>
@@ -9039,7 +9039,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/re-painting-that-given-me-huge-recognition-among-the-artist-community-of-my-city-1726</loc>
@@ -9047,7 +9047,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-attacks-syria-russia-stops-idlib-extremists-from-joining-attack-and-us-killed-20m-since-wwii-1728</loc>
@@ -9055,7 +9055,7 @@
             2019-01-20
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/developerhonestcash-1729</loc>
@@ -9063,7 +9063,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/re-re-painting-that-given-me-huge-recognition-among-the-artist-community-of-my-city-1730</loc>
@@ -9071,7 +9071,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/what-is-tcpip-and-how-does-it-work-1731</loc>
@@ -9079,7 +9079,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/bitcoin-cash-finalmente-es-libre-de-la-influencia-de-faketoshi-1734</loc>
@@ -9087,7 +9087,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emrosedallara/re-a-cold-crypto-wallet-will-be-the-legacy-i-leave-for-my-daughter-1736</loc>
@@ -9095,7 +9095,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Cryptopineapple/re-re-a-cold-crypto-wallet-will-be-the-legacy-i-leave-for-my-daughter-1737</loc>
@@ -9103,7 +9103,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/videos-suggesting-us-fed-gov-abuses-its-powers-to-send-messages-to-internet-freedom-activists-ross-and-swartz-1739</loc>
@@ -9111,7 +9111,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/saddit42/re-re-re-painting-that-given-me-huge-recognition-among-the-artist-community-of-my-city-1741</loc>
@@ -9119,7 +9119,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-current-wish-list-for-honestcash-1743</loc>
@@ -9127,7 +9127,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/girl-with-the-beanie-1744</loc>
@@ -9135,7 +9135,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/nice-page-to-watch-bch-transactions-1745</loc>
@@ -9143,7 +9143,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-attacks-syria-twice-in-24hrs-yellow-vests-go-global-and-dhs-buses-leave-immigrants-in-arizona-1746</loc>
@@ -9151,7 +9151,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/anarchovegan/ideal-fully-functional-pocket-laptop-computer-phone-1747</loc>
@@ -9159,7 +9159,7 @@
             2019-01-21
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/slow-start-to-2019-for-initial-coin-offerings-1749</loc>
@@ -9167,7 +9167,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/how-to-buy-bitcoin-anonymously-1750</loc>
@@ -9175,7 +9175,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JZA/eos-vs-tron-project-comparison-1751</loc>
@@ -9183,7 +9183,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JZA/anime-2019-what-am-i-watching-1752</loc>
@@ -9191,7 +9191,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JZA/long-live-the-king-1753</loc>
@@ -9199,7 +9199,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JZA/paccoin-y-su-contribucion-a-mi-podcast-1754</loc>
@@ -9207,7 +9207,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/the-bibles-most-useful-bits-1755</loc>
@@ -9215,7 +9215,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/re-my-current-wish-list-for-honestcash-1756</loc>
@@ -9223,7 +9223,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-re-my-current-wish-list-for-honestcash-1757</loc>
@@ -9231,7 +9231,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bitwise/re-a-riddle-for-honestcash-1759</loc>
@@ -9239,7 +9239,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/re-re-a-riddle-for-honestcash-1761</loc>
@@ -9247,7 +9247,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/re-can-hc-survive-without-censorship-1762</loc>
@@ -9255,7 +9255,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/drawing-an-indian-saint-with-black-pen-1763</loc>
@@ -9263,7 +9263,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/m4ktub/re-drawing-an-indian-saint-with-black-pen-1764</loc>
@@ -9271,7 +9271,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/love-a-beautiful-poem-on-love-by-oodeyaa-1766</loc>
@@ -9279,7 +9279,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/whotippedit/re-re-honestwhotippedit-1767</loc>
@@ -9287,7 +9287,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/whotippedit/re-developerhonestcash-1768</loc>
@@ -9295,7 +9295,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/electroneum-ios-launch-1769</loc>
@@ -9303,7 +9303,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/re-can-hc-survive-without-censorship-1770</loc>
@@ -9311,7 +9311,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/zcash-is-now-the-14th-crypto-asset-to-be-added-to-etoro-1771</loc>
@@ -9319,7 +9319,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/re-re-drawing-an-indian-saint-with-black-pen-1772</loc>
@@ -9327,7 +9327,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/calisi/murder-that-united-people-assassination-of-hrant-dink-armenian-activist-1773</loc>
@@ -9335,7 +9335,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/re-can-hc-survive-without-censorship-1774</loc>
@@ -9343,7 +9343,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/como-evitar-la-censura-del-gobierno-venezolano-para-internet-1775</loc>
@@ -9351,7 +9351,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oscar/spanish-police-in-catalan-referendum-october-1-2017-1776</loc>
@@ -9359,7 +9359,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/how-to-avoid-censorship-of-the-venezuelan-government-for-internet-1777</loc>
@@ -9367,7 +9367,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israels-targeting-iran-lie-revealed-us-backed-venezuela-regime-change-underway-and-us-opioid-lies-1778</loc>
@@ -9375,7 +9375,7 @@
             2019-01-22
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/honest-cash-better-than-google-1779</loc>
@@ -9383,7 +9383,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/mattcriptoactivos/podcast-with-honest-cash-founder-help-venezuela-1780</loc>
@@ -9391,7 +9391,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/please-show-responses-in-categories-1781</loc>
@@ -9399,7 +9399,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/flashmob96/few-tips-for-making-your-kick-drum-sound-better-in-the-mix-1782</loc>
@@ -9407,7 +9407,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-a-riddle-for-honestcash-1783</loc>
@@ -9415,7 +9415,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/re-re-a-riddle-for-honestcash-1784</loc>
@@ -9423,7 +9423,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/my-novel-chapter-9-continued-1785</loc>
@@ -9431,7 +9431,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/the-private-sector-is-private-property-1786</loc>
@@ -9439,7 +9439,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/somospolvo/first-it-is-necessary-to-reform-the-spanish-constitution-1788</loc>
@@ -9447,7 +9447,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/making-of-spiderman-with-stadler-colour-pencil-part-1-1789</loc>
@@ -9455,7 +9455,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/honest-cash-is-a-market-so-what-1790</loc>
@@ -9463,7 +9463,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-a-riddle-for-honestcash-any-sound-induced-by-a-human-1791</loc>
@@ -9471,7 +9471,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/re-re-a-riddle-for-honestcash-any-sound-induced-by-a-human-1793</loc>
@@ -9479,7 +9479,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/artpower/hello-friends-i-am-shruti-singh-from-india-1794</loc>
@@ -9487,7 +9487,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/bitcoin-history-part-3-1795</loc>
@@ -9495,7 +9495,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/re-a-riddle-for-honestcash-1796</loc>
@@ -9503,7 +9503,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/re-hello-friends-i-am-shruti-singh-from-india-1797</loc>
@@ -9511,7 +9511,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/artpower/watercolour-portrait-of-a-beautiful-lady-1798</loc>
@@ -9519,7 +9519,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/re-watercolour-portrait-of-a-beautiful-lady-1799</loc>
@@ -9527,7 +9527,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darkson/the-honestcash-site-got-way-better-1801</loc>
@@ -9535,7 +9535,7 @@
             2019-01-23
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/samanthastandish/theres-no-such-thing-as-property-1803</loc>
@@ -9543,7 +9543,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/flagrant-us-venezuela-regime-change-with-msm-distractions-and-syria-threatens-to-attack-israeli-airport-1805</loc>
@@ -9551,7 +9551,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/welcoming-jordan-hall-to-cent-1807</loc>
@@ -9559,7 +9559,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/bitcoincashnotes_com/our-first-uncensorable-post-1810</loc>
@@ -9567,7 +9567,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/i-pray-to-god-a-beautiful-poem-by-oodeyaa-1811</loc>
@@ -9575,7 +9575,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/alrashel/a-successful-crypto-trader-1813</loc>
@@ -9583,7 +9583,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/were-all-on-this-ride-together-1814</loc>
@@ -9591,7 +9591,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yantri/genie-and-other-inventions-a-short-story-en-1815</loc>
@@ -9599,7 +9599,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yantri/dzin-i-inne-wynalazki-opowiadanie-pl-1816</loc>
@@ -9607,7 +9607,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/MaelstrohmBlack/mournful-salute-and-reverence-1817</loc>
@@ -9615,7 +9615,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-my-current-wish-list-for-honestcash-1818</loc>
@@ -9623,7 +9623,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/pencil-sketch-portrait-of-a-beautiful-girl-1820</loc>
@@ -9631,7 +9631,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Geri/tiszazugi-gendercide-1821</loc>
@@ -9639,7 +9639,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/artpower/watercolour-portrait-of-a-beautiful-lady-final-part-1822</loc>
@@ -9647,7 +9647,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/boldman-capital-earn-eth-dividends-1823</loc>
@@ -9655,7 +9655,7 @@
             2019-01-24
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/the-distribution-of-influence-1826</loc>
@@ -9663,7 +9663,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/31-de-caida-en-el-tamano-promedio-de-las-transacciones-tuvo-bitcoin-en-el-2018-segun-reporte-de-circle-1828</loc>
@@ -9671,7 +9671,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-tiszazugi-gendercide-1829</loc>
@@ -9679,7 +9679,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/new-york-regulator-grants-licenses-to-robinhood-crypto-and-libertyx-1830</loc>
@@ -9687,7 +9687,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/us-interim-government-coups-in-venezuela-syria-yemen-congo-etc-heshemi-freed-and-gaza-attacked-1831</loc>
@@ -9695,7 +9695,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/cognitive-diversity-1833</loc>
@@ -9703,7 +9703,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Geri/re-re-reply-1834</loc>
@@ -9711,7 +9711,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/until-when-jp-morgan-and-its-war-to-bitcoin-bitcoin-will-fall-below-dollar-1500-and-financial-institutions-will-withdraw-1835</loc>
@@ -9719,7 +9719,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/hobo-report-1222019-1837</loc>
@@ -9727,7 +9727,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/hobo-digest-the-free-content-anomaly-1838</loc>
@@ -9735,7 +9735,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/UnstoppableCash/wired-article-shouldnt-we-all-have-seamless-micropayments-by-now-1839</loc>
@@ -9743,7 +9743,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/re-keep-up-the-good-work-1840</loc>
@@ -9751,7 +9751,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/re-push-down-trash-or-pull-up-treasure-1841</loc>
@@ -9759,7 +9759,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/samanthastandish/re-the-distribution-of-influence-1842</loc>
@@ -9767,7 +9767,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/the-lion-and-the-eagle-1843</loc>
@@ -9775,7 +9775,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/re-daydreaming-rosa-1844</loc>
@@ -9783,7 +9783,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/re-re-daydreaming-rosa-1845</loc>
@@ -9791,7 +9791,7 @@
             2019-01-25
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/re-wired-article-shouldnt-we-all-have-seamless-micropayments-by-now-1846</loc>
@@ -9799,7 +9799,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/re-watercolour-portrait-of-a-beautiful-lady-final-part-1847</loc>
@@ -9807,7 +9807,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-theres-no-such-thing-as-property-1848</loc>
@@ -9815,7 +9815,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/venezuelas-deal-with-russia-2-days-before-coup-fed-spending-down-only-7-and-cannabis-kills-30000-1849</loc>
@@ -9823,7 +9823,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/free-content-isnt-equally-valuable-1850</loc>
@@ -9831,7 +9831,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/original-musical-content-oscillatewildly-swell-1851</loc>
@@ -9839,7 +9839,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/samanthastandish/re-re-theres-no-such-thing-as-property-1852</loc>
@@ -9847,7 +9847,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/swiss-bank-partners-with-bitstamp-to-enable-btc-funding-and-withdrawals-1853</loc>
@@ -9855,7 +9855,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/bitcoin-history-part-4-casascium-creates-physical-bitcoins-1854</loc>
@@ -9863,7 +9863,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/surviving-a-51-attack-1855</loc>
@@ -9871,7 +9871,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/re-free-content-isnt-equally-valuable-1856</loc>
@@ -9879,7 +9879,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/draft-testing-center-style-1857</loc>
@@ -9887,7 +9887,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/tom/re-draft-testing-center-style-1860</loc>
@@ -9895,7 +9895,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JonathanSilverblood/re-re-draft-testing-center-style-1861</loc>
@@ -9903,7 +9903,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/steemit-vs-honest-cash-1863</loc>
@@ -9911,7 +9911,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-re-re-draft-testing-center-style-1864</loc>
@@ -9919,7 +9919,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/beautiful-landscape-painting-with-watercolour-1866</loc>
@@ -9927,7 +9927,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/re-the-bibles-most-useful-bits-1867</loc>
@@ -9935,7 +9935,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/im_uname/re-can-hc-survive-without-censorship-1869</loc>
@@ -9943,7 +9943,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/making-of-spiderman-with-stadler-pencil-final-part-1871</loc>
@@ -9951,7 +9951,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/artpower/making-of-my-favorite-the-wolverine-1872</loc>
@@ -9959,7 +9959,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/re-re-re-just-one-more-leap-of-faith-1873</loc>
@@ -9967,7 +9967,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/the-character-a-sonnet-by-oodeyaa-1875</loc>
@@ -9975,7 +9975,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCashCom/bitcoin-cash-1876</loc>
@@ -9983,7 +9983,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/BitcoinCashCom/bitcoin-cash-development-video-meeting-3-january-31-2019-2300-utc-1877</loc>
@@ -9991,7 +9991,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-the-murder-that-united-people-in-the-memory-of-hrant-dink-armenian-activist-1878</loc>
@@ -9999,7 +9999,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/why-gold-had-a-value-and-why-bch-has-a-value-1879</loc>
@@ -10007,7 +10007,7 @@
             2019-01-26
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/bitcoin-core-vs-bitcoin-cash-1880</loc>
@@ -10015,7 +10015,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/richze90/get-started-with-crypto-in-one-minute-1881</loc>
@@ -10023,7 +10023,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/praise-seldon-1882</loc>
@@ -10031,7 +10031,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/an-in-depth-look-at-the-trezor-model-t-hardware-wallet-1883</loc>
@@ -10039,7 +10039,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/satoshis-bitcoin-whitepaper-is-now-available-in-arabic-and-hindi-1885</loc>
@@ -10047,7 +10047,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/bitcoin-history-part-5-a-wild-altcoin-appears-1886</loc>
@@ -10055,7 +10055,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/riveting-content-1888</loc>
@@ -10063,7 +10063,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/chapter-10-1889</loc>
@@ -10071,7 +10071,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/AD1AD/re-riveting-content-1890</loc>
@@ -10079,7 +10079,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/my-gratitude-to-the-person-who-brings-me-here-on-honestcash-oodeyaa-1891</loc>
@@ -10087,7 +10087,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/re-my-gratitude-to-the-person-who-brings-me-here-on-honestcash-oodeyaa-1892</loc>
@@ -10095,7 +10095,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Geri/re-activist-1894</loc>
@@ -10103,7 +10103,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kain_niaK/my-new-trance-track-antebellum-1895</loc>
@@ -10111,7 +10111,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/merc1er/re-my-new-trance-track-antebellum-1896</loc>
@@ -10119,7 +10119,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kain_niaK/re-re-my-new-trance-track-antebellum-1897</loc>
@@ -10127,7 +10127,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/blockparty/fountainheadcash-or-bitdb-development-on-bitcoin-cash-lives-on-1898</loc>
@@ -10135,7 +10135,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/introducing-vitalik-buterin-to-msws-1899</loc>
@@ -10143,7 +10143,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/dylanvoid/crypto-characters-bsv-might-be-a-tad-unpopular-1900</loc>
@@ -10151,7 +10151,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Neil/the-ethereum-casper-protocol-1901</loc>
@@ -10159,7 +10159,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/re-re-re-re-re-re-re-re-riveting-content-1902</loc>
@@ -10167,7 +10167,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/portrait-of-sara-1903</loc>
@@ -10175,7 +10175,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/sploit/generate-bitcoin-cash-receiving-addresses-from-an-electron-cash-xpub-key-1906</loc>
@@ -10183,7 +10183,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/nandibear/luke-nandibear-taking-a-break-from-life-in-the-states-bitcoin-cash-free-the-world-2019-1909</loc>
@@ -10191,7 +10191,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/introducing-scott-h-young-to-msws-1911</loc>
@@ -10199,7 +10199,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/waves-technical-analysis-winner-of-the-day-1912</loc>
@@ -10207,7 +10207,7 @@
             2019-01-27
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/us-point-man-for-venezuela-convicted-war-criminal-and-yellow-vests-meet-the-red-scarves-opposition-1913</loc>
@@ -10215,7 +10215,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/a-lad-makes-me-glad-1914</loc>
@@ -10223,7 +10223,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-us-point-man-for-venezuela-convicted-war-criminal-and-yellow-vests-meet-the-red-scarves-opposition-1915</loc>
@@ -10231,7 +10231,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cryptocrazy/have-you-ever-participated-in-an-event-called-proof-of-keys-1916</loc>
@@ -10239,7 +10239,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emergent_reasons/what-is-a-payment-code-bip47-and-how-can-i-make-one-with-electron-cash-1919</loc>
@@ -10247,7 +10247,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Logan/re-the-lion-and-the-eagle-1920</loc>
@@ -10255,7 +10255,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/find-happiness-in-little-things-part-1-1922</loc>
@@ -10263,7 +10263,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hattaarshavin/atletico-madrid-perpendek-poin-dengan-barcelona-1923</loc>
@@ -10271,7 +10271,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/the-eradication-of-bad-beliefs-markets-vs-democracies-1924</loc>
@@ -10279,7 +10279,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Itstony/introduction-1926</loc>
@@ -10287,7 +10287,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/CloseCircle/how-blockchain-will-disrupt-design-and-designers-1927</loc>
@@ -10295,7 +10295,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/re-honest-cash-just-became-more-transparent-1928</loc>
@@ -10303,7 +10303,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/hash-rate-oscillations-in-bitcoin-cash-1929</loc>
@@ -10311,7 +10311,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Chronos/the-hoarders-generosity-1931</loc>
@@ -10319,7 +10319,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/decentralized-cryptocurrency-dreams-1932</loc>
@@ -10327,7 +10327,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/back-to-basics-what-is-money-1933</loc>
@@ -10335,7 +10335,7 @@
             2019-01-28
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/LizbethAlviarez/money-blockchain-and-children-1934</loc>
@@ -10343,7 +10343,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/LizbethAlviarez/dinero-blockchain-y-los-ninos-1935</loc>
@@ -10351,7 +10351,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/vanessa-beeley-interview-yellow-vests-police-violence-and-the-suppression-of-a-global-movement-1936</loc>
@@ -10359,7 +10359,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chainxor/re-whats-coming-for-honest-in-the-next-days-recommendations-1937</loc>
@@ -10367,7 +10367,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/richze90/paying-with-bitcoin-what-you-need-to-know-1939</loc>
@@ -10375,7 +10375,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SpendBCH/re-fountainheadcash-or-bitdb-development-on-bitcoin-cash-lives-on-1940</loc>
@@ -10383,7 +10383,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/fmr-un-expert-says-sanctions-responsible-for-venezuela-and-official-exposes-fdas-big-pharma-loyalty-1941</loc>
@@ -10391,7 +10391,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-find-happiness-in-little-things-part-1-1942</loc>
@@ -10399,7 +10399,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/re-re-the-lion-and-the-eagle-1944</loc>
@@ -10407,7 +10407,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JZA/amantes-del-blockchain-noticias-enero-26-2019-1945</loc>
@@ -10415,7 +10415,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/JZA/amantes-del-blockchain-analisis-de-mercado-29-de-enero-1946</loc>
@@ -10423,7 +10423,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/amar/my-introduction-1947</loc>
@@ -10431,7 +10431,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/o-poverty-a-sonnet-by-oodeyaa-1948</loc>
@@ -10439,7 +10439,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/re-re-find-happiness-in-little-things-part-1-1949</loc>
@@ -10447,7 +10447,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/amar/ranji-trophy-saurashtra-won-the-semi-finals-between-saurashtra-and-karnataka-1950</loc>
@@ -10455,7 +10455,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/sploit/bitcoin-cash-marketing-images-1951</loc>
@@ -10463,7 +10463,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/amar/ind-vs-nz-this-is-the-reason-behind-the-crushing-defeat-of-the-indian-team-1952</loc>
@@ -10471,7 +10471,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/re-my-introduction-1954</loc>
@@ -10479,7 +10479,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Darwin/re-my-introduction-1955</loc>
@@ -10487,7 +10487,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/thethrowaccount21/coinmarketcap-data-is-misleading-1956</loc>
@@ -10495,7 +10495,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yantri/wieza-opowiadanie-1959</loc>
@@ -10503,7 +10503,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yantri/the-tower-a-short-story-1960</loc>
@@ -10511,7 +10511,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/re-wieza-opowiadanie-1961</loc>
@@ -10519,7 +10519,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yantri/re-re-wieza-opowiadanie-1962</loc>
@@ -10527,7 +10527,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Licho/re-re-re-wieza-opowiadanie-1963</loc>
@@ -10535,7 +10535,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yantri/re-re-re-re-wieza-opowiadanie-1964</loc>
@@ -10543,7 +10543,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/making-a-beautiful-landscape-painting-with-watercolour-1965</loc>
@@ -10551,7 +10551,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/why-is-writing-so-hard-1966</loc>
@@ -10559,7 +10559,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/mattcriptoactivos/human-story-the-bitcoin-lawyer-1967</loc>
@@ -10567,7 +10567,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/senate-quietly-passes-anti-bds-bill-boltons-5000-troops-to-columbia-and-newguards-saudi-ties-1968</loc>
@@ -10575,7 +10575,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/flashmob96/do-we-value-music-enough-1970</loc>
@@ -10583,7 +10583,7 @@
             2019-01-29
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/richze90/appsheet-expand-the-icon-set-to-use-all-unicode-characters-for-column-formatting-1971</loc>
@@ -10591,7 +10591,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chicken/p3cio-project-update-12919-growth-of-the-p3c-ecosystem-1974</loc>
@@ -10599,7 +10599,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/crux/tinyplanet_glitch-1-1978</loc>
@@ -10607,7 +10607,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/crux/tinyplanet-2-1979</loc>
@@ -10615,7 +10615,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/wikipedia-now-accepts-bitcoin-cash-donations-via-bitpay-1983</loc>
@@ -10623,7 +10623,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/re-re-re-my-current-wish-list-for-honestcash-1984</loc>
@@ -10631,7 +10631,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kain_niaK/does-anybody-know-how-to-get-my-honestcash-wallet-in-to-electron-cash-1985</loc>
@@ -10639,7 +10639,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/time-lapse-poster-colour-painting-of-lord-shri-krishna-1986</loc>
@@ -10647,7 +10647,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kain_niaK/re-does-anybody-know-how-to-get-my-honestcash-wallet-in-to-electron-cash-1987</loc>
@@ -10655,7 +10655,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/artpower/watercolour-portrait-of-bollywood-actress-deepika-padukone-1988</loc>
@@ -10663,7 +10663,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/how-to-achieve-your-dreams-ten-suggestions-that-can-work-1989</loc>
@@ -10671,7 +10671,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/mattcriptoactivos/proof-of-work-vs-proof-of-stake-podcast-1990</loc>
@@ -10679,7 +10679,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kain_niaK/alien-signal-1991</loc>
@@ -10687,7 +10687,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/macronmaduro-hypocrisy-cnn-tries-to-manufacture-consent-fcc-5g-collusion-and-the-us-groomed-guaido-1992</loc>
@@ -10695,7 +10695,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TheOneLaw/re-re-does-anybody-know-how-to-get-my-honestcash-wallet-in-to-electron-cash-1993</loc>
@@ -10703,7 +10703,7 @@
             2019-01-30
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/proof-of-writing-1995</loc>
@@ -10711,7 +10711,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/the-wrapped-bitcoin-wbtc-project-has-officially-launched-on-ethereum-1997</loc>
@@ -10719,7 +10719,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/chapter-10-continued-1998</loc>
@@ -10727,7 +10727,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/new-institutional-crypto-wallet-korean-won-stable-coin-2000</loc>
@@ -10735,7 +10735,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/electroneum-ios-beta-review-2001</loc>
@@ -10743,7 +10743,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/no-shadow-without-light-2002</loc>
@@ -10751,7 +10751,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Dayveedben/first-post-2003</loc>
@@ -10759,7 +10759,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/cryptocurrencies-and-wallets-of-the-future-2006</loc>
@@ -10767,7 +10767,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/re-why-do-we-hate-ads-so-much-2008</loc>
@@ -10775,7 +10775,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/withdrawing-to-blocktrades-issue-2009</loc>
@@ -10783,7 +10783,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/viking-rat-2010</loc>
@@ -10791,7 +10791,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/chainalysis-reports-more-than-a-billion-dollars-in-crypto-stealing-by-two-groups-of-hackers-2011</loc>
@@ -10799,7 +10799,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/bubble-house-2012</loc>
@@ -10807,7 +10807,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/upside-down-house-2013</loc>
@@ -10815,7 +10815,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/samanthastandish/custodial-services-for-cryptocurrency-is-an-oxymoron-2016</loc>
@@ -10823,7 +10823,7 @@
             2019-01-31
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/un-banned-from-khashoggi-crime-scene-us-bans-venezuelas-cryptocurrency-and-eradication-of-alt-voices-2018</loc>
@@ -10831,7 +10831,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/why-paywalls-are-important-2020</loc>
@@ -10839,7 +10839,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/marconi-introduces-developer-testing-network-to-secure-complex-cloud-networks-2022</loc>
@@ -10847,7 +10847,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Big_Bubbler/some-mass-user-migration-possibilities-2024</loc>
@@ -10855,7 +10855,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/firstuser123/hello-world-2025</loc>
@@ -10863,7 +10863,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/amar/the-2021-champions-trophy-and-the-2023-world-cup-will-be-played-on-the-indian-soil-2027</loc>
@@ -10871,7 +10871,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Bankthecrypto/my-first-post-2028</loc>
@@ -10879,7 +10879,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/expression-of-love-pencil-sketch-art-work-2029</loc>
@@ -10887,7 +10887,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/expression-of-love-pencil-sketch-art-work-2031</loc>
@@ -10895,7 +10895,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/user/re-steemit-vs-honest-cash-2032</loc>
@@ -10903,7 +10903,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/eprolific/re-bitcoin-core-vs-bitcoin-cash-2033</loc>
@@ -10911,7 +10911,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/the-united-states-has-placed-visa-restriction-on-ghana-2034</loc>
@@ -10919,7 +10919,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/eprolific/introducing-my-honest-self-in-the-honestcash-platform-2035</loc>
@@ -10927,7 +10927,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/6-philanthropic-projects-that-that-accept-cryptocurrency-2037</loc>
@@ -10935,7 +10935,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-hello-world-2038</loc>
@@ -10943,7 +10943,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/djkckelvin/learning-from-mistake-2040</loc>
@@ -10951,7 +10951,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/relevant-vs-honest-cash-2041</loc>
@@ -10959,7 +10959,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/conrad_murkins/tips-for-maintaining-positive-mental-health-2042</loc>
@@ -10967,7 +10967,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/promoting-your-posts-2043</loc>
@@ -10975,7 +10975,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/firstuser123/re-re-hello-world-2044</loc>
@@ -10983,7 +10983,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-re-re-hello-world-2045</loc>
@@ -10991,7 +10991,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/ABondGirl2/re-making-a-beautiful-landscape-painting-with-watercolour-2046</loc>
@@ -10999,7 +10999,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/adrianbarwicki/re-re-re-honestwhotippedit-2047</loc>
@@ -11007,7 +11007,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/phabulu/today-we-completed-411-days-of-bitcoin-bear-market-we-match-the-bear-market-2013-to-2015-2048</loc>
@@ -11015,7 +11015,7 @@
             2019-02-01
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/paywalls-shouldnt-be-a-priority-2049</loc>
@@ -11023,7 +11023,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/photo-friday-canary-wharf-2050</loc>
@@ -11031,7 +11031,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/its-raining-outside-right-now-2051</loc>
@@ -11039,7 +11039,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Shaman/new-to-the-platform-2053</loc>
@@ -11047,7 +11047,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/hobomedia/re-paywalls-shouldnt-be-a-priority-2054</loc>
@@ -11055,7 +11055,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-new-to-the-platform-2055</loc>
@@ -11063,7 +11063,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-50-minutes-to-motivation-2056</loc>
@@ -11071,7 +11071,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-new-to-the-platform-2058</loc>
@@ -11079,7 +11079,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-promoting-your-posts-2060</loc>
@@ -11087,7 +11087,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/alrashel/wrapped-bitcoinwbtc-new-sensation-2061</loc>
@@ -11095,7 +11095,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/oodeyaa/find-happiness-in-little-things-the-conclusion-2065</loc>
@@ -11103,7 +11103,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Xerographica/bounties-shouldnt-be-a-priority-2066</loc>
@@ -11111,7 +11111,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/amar/bcci-tired-of-treating-families-enjoying-abroad-with-cricketers-2067</loc>
@@ -11119,7 +11119,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/matewo/the-rise-of-ai-of-why-we-cannot-afford-the-next-bitcoin-bubble-ntb-1-2068</loc>
@@ -11127,7 +11127,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/wordshavemeaning/is-selling-your-own-property-a-privilege-2070</loc>
@@ -11135,7 +11135,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/part-2-chapter-1-2071</loc>
@@ -11143,7 +11143,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/kanada-crypto-exchange-files-for-bankruptcy-after-ceo-dies-with-wallet-keys-2072</loc>
@@ -11151,7 +11151,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/last-week-happenings-in-crypto-world-2073</loc>
@@ -11159,7 +11159,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/properties-are-still-being-sold-for-cryptocurrency-despite-the-bear-market-2074</loc>
@@ -11167,7 +11167,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/wyoming-senate-passes-bill-recognizing-cryptocurrency-2075</loc>
@@ -11175,7 +11175,7 @@
             2019-02-02
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/watercolour-portrait-of-my-dear-friend-2076</loc>
@@ -11183,7 +11183,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-bounties-shouldnt-be-a-priority-2077</loc>
@@ -11191,7 +11191,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/juliawilliams/beautiful-landscape-painting-with-watercolour-2080</loc>
@@ -11199,7 +11199,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/artpower/self-portrait-by-watercolour-2082</loc>
@@ -11207,7 +11207,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/cashshuffle-how-to-install-and-test-2083</loc>
@@ -11215,7 +11215,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/chainxor/re-cashshuffle-how-to-install-and-test-2087</loc>
@@ -11223,7 +11223,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Abuaish/traders-patiently-wait-for-cryptos-longest-bear-run-to-end-2089</loc>
@@ -11231,7 +11231,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Numberofthings/bittorrent-on-trx-napster-20-2091</loc>
@@ -11239,7 +11239,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Numberofthings/re-benefits-of-upvoting-great-content-early-2092</loc>
@@ -11247,7 +11247,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Numberofthings/what-is-ray-tracing-featuring-quake-ii-hosted-by-numberofthings-2093</loc>
@@ -11255,7 +11255,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Numberofthings/cigarette-smoke-and-coffee-stains-original-music-2094</loc>
@@ -11263,7 +11263,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Numberofthings/alienware-r15-thermal-paste-replacement-2095</loc>
@@ -11271,7 +11271,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/TLAVagabond/israel-is-a-criminal-state-purdue-pharmas-secret-addiction-plan-and-covert-us-action-in-venezuela-2097</loc>
@@ -11279,7 +11279,7 @@
             2019-02-03
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/GersonArellano/hello-everyone-im-gerson-and-this-is-my-presentation-2098</loc>
@@ -11287,7 +11287,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Numberofthings/black-pearl-dividends-relaunch-on-trx-today-2100</loc>
@@ -11295,7 +11295,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/yk101/introducingthe-news-this-week-1-2101</loc>
@@ -11303,7 +11303,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SILENTSAM/sylvester-rd-trails-stave-lake-2102</loc>
@@ -11311,7 +11311,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Logan/re-cashshuffle-how-to-install-and-test-2103</loc>
@@ -11319,7 +11319,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/re-re-cashshuffle-how-to-install-and-test-2106</loc>
@@ -11327,7 +11327,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Coins4Clothes/coins-4-clothes-bitcoin-cash-charity-expands-to-12-canadian-cities-2107</loc>
@@ -11335,7 +11335,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Shaman/is-mental-health-still-taboo-in-2019-2109</loc>
@@ -11343,7 +11343,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-is-mental-health-still-taboo-in-2019-2110</loc>
@@ -11351,7 +11351,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Kain_niaK/i-was-in-a-the-kindness-diaries-episode-about-red-deer-2111</loc>
@@ -11359,7 +11359,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/trumanity/re-first-post-2113</loc>
@@ -11367,7 +11367,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/emergent_reasons/re-cashshuffle-how-to-install-and-test-2115</loc>
@@ -11375,7 +11375,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/SakibDevil29/buet-give-a-proposal-to-solve-road-accident-issues-for-bangladesh-government-2116</loc>
@@ -11383,7 +11383,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/raghao/drawing-a-pencil-sketch-of-beautiful-girl-2117</loc>
@@ -11391,7 +11391,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Melooo182/ras-sun-god-ascension-wip-digital-painting-2118</loc>
@@ -11399,7 +11399,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/christroutner/re-re-cashshuffle-how-to-install-and-test-2120</loc>
@@ -11407,7 +11407,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/Daniejjimenez/re-chainalysis-reports-more-than-a-billion-dollars-in-crypto-stealing-by-two-groups-of-hackers-2121</loc>
@@ -11415,7 +11415,7 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
 
         <url>
           <loc>https://honest.cash/cain/re-is-mental-health-still-taboo-in-2019-2122</loc>
@@ -11423,6 +11423,6 @@
             2019-02-04
           </lastmod>
         </url>
-      
+
     </urlset>
-    
+

--- a/public/templates/partials/footer.html
+++ b/public/templates/partials/footer.html
@@ -6,16 +6,16 @@
               <a href="/about" target="_self"><h6>About</h6></a>
             </li>
             <li>
-              <a href="https://honest.cash/honest_cash/frequently-asked-questions" target="_self"><h6>FAQ</h6></a>
+              <a href="/frequently-asked-questions" target="_self"><h6>FAQ</h6></a>
             </li>
             <li>
-              <a href="https://honest.cash/honest_cash/honest-cash-transparency-report-and-warrant-canary-129" target="_self"><h6>Transparency</h6></a>
+              <a href="/transparency" target="_self"><h6>Transparency</h6></a>
             </li>
             <li>
-              <a href="https://honest.cash/honest_cash/honest-cash-terms-of-service-124" target="_self"><h6>Terms</h6></a>
+              <a href="/terms-of-service" target="_self"><h6>Terms</h6></a>
             </li>
             <li>
-              <a href="https://honest.cash/honest_cash/honestcash-privacy-policy" target="_self"><h6>Privacy</h6></a>
+              <a href="/privacy-policy" target="_self"><h6>Privacy</h6></a>
             </li>
           </ul>
       </div>
@@ -24,4 +24,3 @@
         <a href="https://github.com/honest-cash" target="_self"><h6>&copy;<span>2019</span> honest.cash</h6></a>
       </div>
   </footer>
-  

--- a/public/templates/partials/profile-badge.html
+++ b/public/templates/partials/profile-badge.html
@@ -64,7 +64,7 @@
   <li>
     <a
       style="margin-top: 5px;"
-      href="/honest_cash/frequently-asked-questions/"
+      href="/frequently-asked-questions"
       target="_self"
     >
       help
@@ -73,7 +73,7 @@
   <li>
     <a
       style="margin-top: 5px;"
-      href="/honest_cash/honest-cash-terms-of-service-124/"
+      href="/terms-of-service"
       target="_self"
     >
       terms of service
@@ -82,7 +82,7 @@
   <li>
     <a
       style="margin-top: 5px;"
-      href="/honest_cash/honestcash-privacy-policy/"
+      href="/privacy-policy"
       target="_self"
     >
       privacy policy

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -105,21 +105,21 @@
             </li>
 
             <hr ng-if="user.id" class="visible-xs" style="margin-top: 5px; margin-bottom: 5px;">
-            
+
             <li class="visible-xs" ng-if="user.id">
-              <a style="margin-top: 5px;" href="/honest_cash/frequently-asked-questions/" target="_self">
+              <a style="margin-top: 5px;" href="/frequently-asked-questions" target="_self">
                 help
               </a>
             </li>
 
             <li class="visible-xs" ng-if="user.id">
-              <a style="margin-top: 5px;" href="/honest_cash/honest-cash-terms-of-service-124/" target="_self">
+              <a style="margin-top: 5px;" href="/terms-of-service" target="_self">
                 terms of service
               </a>
             </li>
 
             <li class="visible-xs" ng-if="user.id">
-              <a style="margin-top: 5px;" href="/honest_cash/honestcash-privacy-policy/" target="_self">
+              <a style="margin-top: 5px;" href="/privacy-policy" target="_self">
                 privacy policy
               </a>
             </li>
@@ -155,7 +155,7 @@
          </ul>
       </div>
     </div>
-    
+
 </div>
 
 	<div style="min-height:440px;">

--- a/src/app/feeds/feeds.html
+++ b/src/app/feeds/feeds.html
@@ -35,7 +35,7 @@
           ng-class="{ 'bold': feedScope === 'last-month' }"
         >
           last month
-        </a> · 
+        </a> ·
         <a
         ng-href="/{{feedType}}?feedScope=all-time"
           ng-class="{ 'bold': feedScope === 'all-time' }"
@@ -57,7 +57,7 @@
         Honest is a social network where you can earn Bitcoin Cash if you create
         value. Our mission to improve the quality of content on the internet and
         to get people paid for doing work they love.
-        <a href="https://honest.cash/honest_cash/about-honest-cash"
+        <a target="_self" href="/about-honest-cash"
           >Read more...</a
         >
       </p>
@@ -96,19 +96,22 @@
         </li>
       </ul>
       <div style="margin-top:50px;">
-        <a href="https://honest.cash/honest_cash/frequently-asked-questions"
+        <a target="_self"
+           href="/frequently-asked-questions"
         >FAQ</a
       >
-      <a href="https://honest.cash/honest_cash/about-honest-cash">About</a>
-      <a
-        href="https://honest.cash/honest_cash/honest-cash-transparency-report-and-warrant-canary-129"
+      <a target="_self"
+         href="/about-honest-cash">About</a>
+      <a target="_self"
+        href="/transparency"
         >Transparency</a
       >
-      <a
-        href="https://honest.cash/honest_cash/honest-cash-terms-of-service-124/"
+      <a target="_self"
+        href="/terms-of-service"
         >Terms</a
       >
-      <a href="https://honest.cash/honest_cash/honestcash-privacy-policy"
+      <a target="_self"
+         href="/privacy-policy"
         >Privacy</a
       >
       <br />


### PR DESCRIPTION
added the following routes that dynamically map to story ids to load them from db. it has every capability of a regular story.

routes:
/frequently-asked-questions
/about (this is only visible in /welcome page, I added a button there otherwise that route was not used at all)
/about-honest-cash
/privacy-policy
/terms-of-service
/transparency

also changed sitemap.xml in v1 and v2 urls to anchorLinks